### PR TITLE
refactor(models): rely timestamps on SQLAlchemy's server-side handling

### DIFF
--- a/models/skill.py
+++ b/models/skill.py
@@ -26,17 +26,13 @@ class AgentSkillData(SQLModel, table=True):
     key: str = Field(primary_key=True)
     data: Dict[str, Any] = Field(sa_column=Column(JSONB, nullable=True))
     created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
         sa_type=DateTime(timezone=True),
         sa_column_kwargs={"server_default": func.now()},
         nullable=False,
     )
     updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
         sa_type=DateTime(timezone=True),
-        sa_column_kwargs={
-            "onupdate": lambda: datetime.now(timezone.utc),
-        },
+        sa_column_kwargs={"onupdate": func.now()},
         nullable=False,
     )
 


### PR DESCRIPTION
Remove `default_factory=lambda: datetime.now(timezone.utc)` and rely on SQLAlchemy's server-side handling.

# Pull Request Template

## Description
The default_factory in created_at and updated_at fields is unnecessary when you have server_default=func.now() and onupdate. The server should handle default timestamps instead of the application logic. 

## Type of Change
- [x] Improvement

## Checklist
- [x] I have read the contributing guidelines.

