### PR TITLE
feat: Get Latest Nation Metrics from Dune Analytics API

### DIFF
--- a/skills/nation_metrics/__init__.py
+++ b/skills/nation_metrics/__init__.py
@@ -1,0 +1,103 @@
+"""Crestal Nation skill module for IntentKit.
+
+Loads and initializes skills for fetching Crestal Nation metrics from Dune Analytics API.
+"""
+
+import logging
+from typing import Dict, List, Optional, TypedDict
+
+from abstracts.skill import SkillStoreABC
+from skills.base import SkillConfig, SkillState
+
+from .base import NationBaseTool
+
+logger = logging.getLogger(__name__)
+
+# Cache for skill instances
+_skill_cache: Dict[str, NationBaseTool] = {}
+
+
+class SkillStates(TypedDict):
+    """Type definition for Crestal Nation skill states."""
+
+    fetch_nation_metrics: SkillState
+
+
+class Config(SkillConfig):
+    """Configuration schema for Crestal Nation skills."""
+
+    states: SkillStates
+    api_key: str
+
+
+async def get_skills(
+    config: Config,
+    is_private: bool,
+    store: SkillStoreABC,
+    **kwargs,
+) -> List[NationBaseTool]:
+    """Load Crestal Nation skills based on configuration.
+
+    Args:
+        config: Skill configuration with states and API key.
+        is_private: Whether the context is private (affects skill visibility).
+        store: Skill store for accessing other skills.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        List of loaded Crestal Nation skill instances.
+    """
+    logger.info("Loading Crestal Nation skills")
+    available_skills = []
+
+    for skill_name, state in config["states"].items():
+        logger.debug("Checking skill: %s, state: %s", skill_name, state)
+        if state == "disabled":
+            continue
+        if state == "public" or (state == "private" and is_private):
+            available_skills.append(skill_name)
+
+    loaded_skills = []
+    for name in available_skills:
+        skill = get_nation_skill(name, store)
+        if skill:
+            logger.info("Successfully loaded skill: %s", name)
+            loaded_skills.append(skill)
+        else:
+            logger.warning("Failed to load skill: %s", name)
+
+    return loaded_skills
+
+
+def get_nation_skill(
+    name: str,
+    store: SkillStoreABC,
+) -> Optional[NationBaseTool]:
+    """Retrieve a Crestal Nation skill instance by name.
+
+    Args:
+        name: Name of the skill (e.g., 'fetch_nation_metrics').
+        store: Skill store for accessing other skills.
+
+    Returns:
+        Crestal Nation skill instance or None if not found or import fails.
+    """
+    if name in _skill_cache:
+        logger.debug("Retrieved cached skill: %s", name)
+        return _skill_cache[name]
+
+    try:
+        if name == "fetch_nation_metrics":
+            from .fetch_nation_metrics import FetchNationMetrics
+
+            _skill_cache[name] = FetchNationMetrics(skill_store=store)
+        else:
+            logger.warning("Unknown Crestal Nation skill: %s", name)
+            return None
+
+        logger.debug("Cached new skill instance: %s", name)
+        return _skill_cache[name]
+
+    except ImportError as e:
+        logger.error("Failed to import Crestal Nation skill %s: %s", name, e)
+        return None

--- a/skills/nation_metrics/base.py
+++ b/skills/nation_metrics/base.py
@@ -1,0 +1,49 @@
+"""Base module for Crestal Nation skills.
+
+Defines the base class and shared utilities for Crestal Nation skills.
+"""
+
+from typing import Type
+
+from langchain.tools.base import ToolException
+from pydantic import BaseModel, Field
+
+from abstracts.skill import SkillStoreABC
+from skills.base import IntentKitSkill, SkillContext
+
+BASE_URL = "https://api.dune.com/api/v1/query/"
+
+
+class NationBaseTool(IntentKitSkill):
+    """Base class for Crestal Nation skills.
+
+    Provides common functionality for interacting with the Dune Analytics API,
+    including API key retrieval and skill store access.
+    """
+
+    name: str = Field(description="Tool name")
+    description: str = Field(description="Tool description")
+    args_schema: Type[BaseModel]
+    skill_store: SkillStoreABC = Field(description="Skill store for data persistence")
+
+    def get_api_key(self, context: SkillContext) -> str:
+        """Retrieve the Dune Analytics API key from context.
+
+        Args:
+            context: Skill context containing configuration.
+
+        Returns:
+            API key string.
+
+        Raises:
+            ToolException: If the API key is not found.
+        """
+        api_key = context.config.get("api_key")
+        if not api_key:
+            raise ToolException("Dune API key not found in context.config['api_key']")
+        return api_key
+
+    @property
+    def category(self) -> str:
+        """Category of the skill."""
+        return "nation_metrics"

--- a/skills/nation_metrics/fetch_nation_metrics.py
+++ b/skills/nation_metrics/fetch_nation_metrics.py
@@ -1,0 +1,230 @@
+"""Skill to fetch Crestal Nation metrics from Dune Analytics API.
+
+Retrieves data for specified metrics (e.g., total users, unique_ai_citizens) or all metrics.
+"""
+
+import difflib
+import re
+from typing import Any, Dict, Type
+
+import httpx
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from abstracts.skill import SkillStoreABC
+from skills.nation_metrics.base import NationBaseTool
+
+SUPPORTED_METRICS = {
+    "total_users": 4858003,
+    "weekly_active_users": 4867200,
+    "unique_ai_citizens": 4857629,
+    "unique_creators": 4844506,
+    "ai_citizens_over_time": 4857629,
+    "chat_messages_over_time": 4857870,
+    "onchain_transactions": 4859895,
+    "total_chat_messages": 4857870,
+    "daily_skill_executions": 4861785,
+    "goods_services": 4859895,
+    "agent_tvl": 4859887,
+    "citizen_market_cap": 4859887,
+}
+METRIC_ALIASES = {
+    "agents": "unique_ai_citizens",
+    "citizens": "unique_ai_citizens",
+    "market_cap": "citizen_market_cap",
+    "nation_market_cap": "citizen_market_cap",
+    "number_of_agents": "unique_ai_citizens",
+    "number_of_citizens": "unique_ai_citizens",
+    "ai_citizens": "unique_ai_citizens",
+    "users": "total_users",
+    "active_users": "weekly_active_users",
+    "creators": "unique_creators",
+    "transactions": "onchain_transactions",
+    "messages": "total_chat_messages",
+    "skill_executions": "daily_skill_executions",
+    "tvl": "agent_tvl",
+}
+BASE_URL = "https://api.dune.com/api/v1/query"
+
+
+class NationMetricsInput(BaseModel):
+    """Input schema for fetching Crestal Nation metrics."""
+
+    metric: str = Field(
+        default="",
+        description="Metric to fetch (e.g., total_users, agents, market_cap). Empty for all metrics.",
+    )
+
+
+class MetricData(BaseModel):
+    """Data model for a single Crestal Nation metric's data."""
+
+    metric: str = Field(description="Metric name")
+    data: Dict[str, Any] = Field(description="Metric data from Dune API")
+    error: str = Field(default="", description="Error message if fetch failed")
+
+
+class NationMetricsOutput(BaseModel):
+    """Output schema for Crestal Nation metrics."""
+
+    metrics: Dict[str, MetricData] = Field(
+        description="Dictionary of metric names to their data"
+    )
+    summary: str = Field(description="Summary of fetched metrics")
+
+
+class FetchNationMetrics(NationBaseTool):
+    """Skill to fetch Crestal Nation metrics from Dune Analytics API."""
+
+    name: str = "fetch_nation_metrics"
+    description: str = (
+        "Fetches Crestal Nation metrics (e.g., total users, agents/citizens, market cap) from Dune Analytics API. "
+        "Supports specific metrics or all metrics if none specified. Handles rate limits with retries."
+    )
+    args_schema: Type[BaseModel] = NationMetricsInput
+    skill_store: SkillStoreABC = Field(description="Skill store for data persistence")
+
+    def normalize_metric(self, metric: str) -> str:
+        """Normalize a metric string for matching.
+
+        Args:
+            metric: Raw metric string from input.
+
+        Returns:
+            Normalized metric string (lowercase, underscores, no punctuation).
+        """
+        if not metric:
+            return ""
+        # Convert to lowercase, replace spaces/punctuation with underscores, remove extra underscores
+        metric = re.sub(r"[^\w\s]", "", metric.lower()).replace(" ", "_")
+        metric = re.sub(r"_+", "_", metric).strip("_")
+        return metric
+
+    def find_closest_metrics(self, metric: str, max_suggestions: int = 3) -> list[str]:
+        """Find the closest matching metrics using fuzzy matching.
+
+        Args:
+            metric: Input metric to match against.
+            max_suggestions: Maximum number of suggestions to return.
+
+        Returns:
+            List of closest metric names.
+        """
+        all_metrics = list(SUPPORTED_METRICS.keys()) + list(METRIC_ALIASES.keys())
+        if not metric or not all_metrics:
+            return []
+        # Use difflib to find closest matches
+        matches = difflib.get_close_matches(
+            metric, all_metrics, n=max_suggestions, cutoff=0.6
+        )
+        return matches
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_exponential(multiplier=5, min=5, max=60)
+    )
+    async def fetch_data(
+        self, query_id: int, api_key: str, limit: int = 1000
+    ) -> Dict[str, Any]:
+        """Fetch data for a specific Crestal Nation query from Dune Analytics API.
+
+        Args:
+            query_id: Dune query ID.
+            api_key: Dune API key.
+            limit: Maximum number of results (default 1000).
+
+        Returns:
+            Dictionary of query results.
+
+        Raises:
+            ToolException: If the API request fails.
+        """
+        from langchain.tools.base import ToolException
+
+        url = f"{BASE_URL}/{query_id}/results?limit={limit}"
+        headers = {"X-Dune-API-Key": api_key}
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, headers=headers, timeout=10)
+                response.raise_for_status()
+                return response.json().get("result", {})
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                raise ToolException(f"Error fetching data from Dune API: {e}")
+
+    async def _arun(
+        self,
+        metric: str = "",
+        config: RunnableConfig = None,
+        **kwargs,
+    ) -> NationMetricsOutput:
+        """Fetch Crestal Nation metrics asynchronously.
+
+        Args:
+            metric: Metric to fetch (e.g., total_users, agents). Empty for all metrics.
+            config: Runnable configuration.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            NationMetricsOutput with metric data and summary.
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+        context = self.context_from_config(config)
+        api_key = self.get_api_key(context)
+
+        # Normalize metric
+        metric = self.normalize_metric(metric)
+
+        # Handle aliases
+        metric = METRIC_ALIASES.get(metric, metric)
+
+        results = {}
+        metrics_to_fetch = (
+            SUPPORTED_METRICS
+            if not metric
+            else (
+                {metric: SUPPORTED_METRICS[metric]}
+                if metric in SUPPORTED_METRICS
+                else {}
+            )
+        )
+
+        if not metrics_to_fetch:
+            closest_metrics = self.find_closest_metrics(metric)
+            supported = ", ".join(SUPPORTED_METRICS.keys())
+            suggestions = (
+                f" Did you mean: {', '.join(closest_metrics)}?"
+                if closest_metrics
+                else ""
+            )
+            logger.warning(
+                "Unrecognized metric: %s. Suggested: %s", metric, closest_metrics
+            )
+            return NationMetricsOutput(
+                metrics={},
+                summary=(
+                    f"Invalid metric: {metric}. Supported metrics include: {supported}.{suggestions} "
+                    "Try 'fetch crestal nation metrics total_users' or submit a feature request at "
+                    "https://github.com/crestalnetwork/intentkit."
+                ),
+            )
+
+        for metric_name, query_id in metrics_to_fetch.items():
+            try:
+                data = await self.fetch_data(query_id, api_key)
+                results[metric_name] = MetricData(metric=metric_name, data=data)
+            except Exception as e:
+                results[metric_name] = MetricData(
+                    metric=metric_name, data={}, error=str(e)
+                )
+
+        summary = f"Fetched data for {len([m for m in results.values() if not m.error])}/{len(metrics_to_fetch)} metrics."
+        if any(m.error for m in results.values()):
+            summary += f" Errors occurred for: {', '.join(m.metric for m in results.values() if m.error)}."
+
+        return NationMetricsOutput(metrics=results, summary=summary)
+
+    def _run(self, question: str):
+        raise NotImplementedError("Use _arun for async execution")

--- a/skills/nation_metrics/schema.json
+++ b/skills/nation_metrics/schema.json
@@ -1,0 +1,29 @@
+{
+  "title": "Crestal Nation Skills Configuration",
+  "description": "Configuration for Crestal Nation skills to fetch metrics from Dune Analytics API.",
+  "type": "object",
+  "required": ["states", "api_key"],
+  "properties": {
+    "states": {
+      "title": "Skill States",
+      "type": "object",
+      "required": ["fetch_nation_metrics"],
+      "properties": {
+        "fetch_nation_metrics": {
+          "type": "string",
+          "title": "Fetch Crestal Nation Metrics",
+          "enum": ["disabled", "public", "private"],
+          "x-enum-title": ["Disabled", "Agent Owner + All Users", "Agent Owner Only"],
+          "description": "Fetches Crestal Nation metrics (e.g., total users, agents/citizens, market cap) from Dune Analytics API. Supports specific metrics or all metrics if none specified.",
+          "default": "public"
+        }
+      }
+    },
+    "api_key": {
+      "type": "string",
+      "title": "Dune API Key",
+      "description": "API key for Dune Analytics (X-Dune-API-Key).",
+      "x-sensitive": true
+    }
+  }
+}


### PR DESCRIPTION
# Add Crestal Nation Metrics Skill Module

This PR adds the `nation_metrics` skill module to fetch Crestal Nation metrics from the Dune Analytics API:
- Implemented `fetch_nation_metrics` skill to retrieve metrics like `total_users`, `unique_ai_citizens`, `citizen_market_cap`, etc.
- Added aliases (`agents`, `citizens` for `unique_ai_citizens`; `market_cap` for `citizen_market_cap`) for natural language queries.
- Enabled fetching all metrics when no specific metric is provided.
## Type of Change
- [x] New Feature (nation_metrics module)

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have tested metric fetching, aliases, and error responses.
- [x] All tests passed.
## Testing

![image](https://github.com/user-attachments/assets/8760315f-1784-4a57-a4ed-34cdde5f6e2a)

