### PR TITLE
fix: correct skills path and add webp support in admin schema

### DIFF
--- a/app/admin/schema.py
+++ b/app/admin/schema.py
@@ -24,7 +24,7 @@ schema_router_readonly = APIRouter()
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 # Path to agent schema
-AGENT_SCHEMA_PATH = PROJECT_ROOT / "models" / "agent_schema.json"
+AGENT_SCHEMA_PATH = PROJECT_ROOT / "intentkit" / "models" / "agent_schema.json"
 
 # Skills that require agent owner to provide API keys (should be excluded from auto-generation)
 AGENT_OWNER_API_KEY_SKILLS = {
@@ -253,7 +253,7 @@ async def get_skill_schema(
     **Raises:**
     * `HTTPException` - If the skill is not found or name is invalid
     """
-    base_path = PROJECT_ROOT / "skills"
+    base_path = PROJECT_ROOT / "intentkit" / "skills"
     schema_path = base_path / skill / "schema.json"
     normalized_path = schema_path.resolve()
 
@@ -299,7 +299,7 @@ async def get_skill_icon(
     **Raises:**
     * `HTTPException` - If the skill or icon is not found or name is invalid
     """
-    base_path = PROJECT_ROOT / "skills"
+    base_path = PROJECT_ROOT / "intentkit" / "skills"
     icon_path = base_path / skill / f"{icon_name}.{ext}"
     normalized_path = icon_path.resolve()
 
@@ -314,6 +314,8 @@ async def get_skill_icon(
         if ext == "svg"
         else "image/png"
         if ext in ["png"]
+        else "image/webp"
+        if ext in ["webp"]
         else "image/jpeg"
     )
     return FileResponse(normalized_path, media_type=content_type)


### PR DESCRIPTION
This PR fixes the skills path from 'skills' to 'intentkit/skills' and adds support for webp image format in the admin schema.

Changes:
- Updated base_path in get_skill_schema() to use correct 'intentkit/skills' path
- Updated base_path in get_skill_icon() to use correct 'intentkit/skills' path
- Added webp media type support for skill icons