### PR TITLE
fix: make agent response number field optional

### DIFF
--- a/intentkit/models/agent.py
+++ b/intentkit/models/agent.py
@@ -1319,7 +1319,7 @@ class AgentResponse(BaseModel):
     ]
     # auto increment number by db
     number: Annotated[
-        int,
+        Optional[int],
         PydanticField(
             description="Auto-incrementing number assigned by the system for easy reference",
         ),


### PR DESCRIPTION
This PR makes the `number` field in the `AgentResponse` model optional by changing the type from `int` to `Optional[int]`.

## Changes
- Modified `intentkit/models/agent.py` to make the auto-incrementing number field optional
- This allows for more flexible handling of agent responses where the number might not always be present

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update