### PR TITLE
Add sanitize_privacy method to ChatMessage model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.5-dev5
+
+### 📚 Documentation
+- Update changelog for v0.6.5-dev4
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.5-dev4...v0.6.5-dev5
+
 ## v0.6.5-dev4
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.6.5-dev4
+
+### 🐛 Bug Fixes
+- Fixed agent data types
+- Fixed bug in agent schema
+
+### 🔄 Merged Pull Requests
+- Merge pull request #711 from crestalnetwork/hyacinthus
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.5-dev3...v0.6.5-dev4
+
 ## v0.6.5-dev3
 
 ### 📚 Documentation

--- a/intentkit/models/chat.py
+++ b/intentkit/models/chat.py
@@ -447,6 +447,32 @@ class ChatMessage(ChatMessageCreate):
 
         return resp
 
+    def sanitize_privacy(self) -> "ChatMessage":
+        """Remove sensitive information from the chat message.
+
+        This method clears the message content and removes parameters and response
+        from skill calls while preserving the structure and metadata.
+
+        Returns:
+            ChatMessage: A new ChatMessage instance with sensitive data removed
+        """
+        # Create a copy of the current message
+        sanitized_data = self.model_dump()
+
+        # Clear the message content
+        sanitized_data["message"] = ""
+
+        # Clear sensitive data from skill calls
+        if sanitized_data.get("skill_calls"):
+            for skill_call in sanitized_data["skill_calls"]:
+                # Clear parameters and response while keeping structure
+                skill_call["parameters"] = {}
+                if "response" in skill_call:
+                    skill_call["response"] = ""
+
+        # Return a new ChatMessage instance with sanitized data
+        return ChatMessage.model_validate(sanitized_data)
+
     @classmethod
     async def get(cls, message_id: str) -> Optional["ChatMessage"]:
         async with get_session() as db:


### PR DESCRIPTION
## Summary

This PR adds a new `sanitize_privacy` method to the `ChatMessage` model that removes sensitive information from chat messages while preserving their structure and metadata.

## Changes

- Added `sanitize_privacy()` method to `ChatMessage` class in `intentkit/models/chat.py`
- The method clears message content and removes parameters and response data from skill calls
- Preserves the overall structure and metadata of the message
- Returns a new `ChatMessage` instance with sanitized data

## Purpose

This method enables privacy-safe handling of chat messages by removing sensitive content while maintaining the message structure for logging, analytics, or other purposes where the content itself is not needed.

## Implementation Details

- Creates a copy of the current message using `model_dump()`
- Clears the `message` field
- Iterates through `skill_calls` and removes `parameters` and `response` data
- Returns a new `ChatMessage` instance using `model_validate()`