### PR TITLE
feat: exclude replies from twitter timeline by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v0.6.5
+
+### 🚀 Features
+- Add sanitize_privacy method to ChatMessage model for better privacy handling
+- Add redis_db parameter to all redis connections for improved database management
+
+### 🔧 Improvements
+- Prevent twitter reply skill from replying to own tweets to avoid self-loops
+- Better agent API documentation with improved clarity and examples
+- Enhanced agent documentation with clearer explanations
+
+### 🐛 Bug Fixes
+- Fix agent data types for better type safety
+- Fix bug in agent schema validation
+- Remove number field in agent model to simplify structure
+- Use separate connection for langgraph migration setup to prevent conflicts
+- Fix typo in documentation
+
+### 📚 Documentation
+- Improved agent API documentation
+- Updated changelog entries
+- Better agent documentation structure
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.4...v0.6.5
+
+## v0.6.5-dev7
+
+### 📚 Documentation
+- Better agent API documentation improvements
+
+### 🐛 Bug Fixes
+- Fixed typo in codebase
+
+### 🔧 Improvements
+- Prevent twitter reply skill from replying to own tweets
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.5-dev6...v0.6.5-dev7
+
 ## v0.6.5-dev6
 
 ### 🚀 Features

--- a/LLM.md
+++ b/LLM.md
@@ -83,7 +83,7 @@ IntentKit is an autonomous agent framework that enables creation and management 
 1. Please use gh command to do it.
 2. Make a `git pull` first.
 3. The release number rule is: pre-release is vX.X.X-devX, release is vX.X.X.
-4. Find the last version number in release or pre-release using `git tag`, diff origin/main with it, summarize the release note to build/changelog.md for later use. Calculate the version number of this release. Add a diff link to release note too, the from and to should be the version number.
+4. Find the last version number in release or pre-release using `git tag --sort=-version:refname | head -10`, diff origin/main with it, summarize the release note to build/changelog.md for later use. Calculate the version number of this release. Add a diff link to release note too, the from and to should be the version number.
 5. And also insert the release note to the beginning of CHANGELOG.md (This file contains all history release notes, don't use it in gh command), leave this changed CHANGELOG.md in local, don't commit and push it, we will commit it together with next changes.
 6. Construct `gh release create` command, calculate the next version number, use changelog.md as notes file in gh command.
 7. Use gh to do release only, don't create branch, tag, or pull request.

--- a/intentkit/skills/twitter/get_timeline.py
+++ b/intentkit/skills/twitter/get_timeline.py
@@ -71,6 +71,7 @@ class TwitterGetTimeline(TwitterBaseTool):
                 user_auth=twitter.use_key,
                 max_results=max_results,
                 since_id=since_id,
+                exclude=["replies"],
                 expansions=[
                     "referenced_tweets.id",
                     "referenced_tweets.id.attachments.media_keys",


### PR DESCRIPTION
## Summary

This PR improves the Twitter timeline skill by excluding replies from the timeline results by default.

## Changes

- Added `exclude=["replies"]` parameter to the Twitter API call in `get_timeline.py`
- This provides cleaner timeline results by filtering out reply tweets

## Benefits

- Cleaner timeline data for agents
- Reduces noise in timeline results
- Focuses on original tweets and retweets rather than conversational replies

## Testing

- The change uses the standard Twitter API parameter for excluding replies
- No breaking changes to existing functionality