### PR TITLE
Fix autonomous task serialization in agent operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.6.7-dev3
+
+### 🚀 Features
+- **feat: add autonomous task info in entrypoint rules system prompt** - Enhanced autonomous task execution with better context information including task ID, name, description, and scheduling details
+
+### 🐛 Bug Fixes
+- **fix: autonomous skill bug** - Fixed issues related to autonomous skill execution
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.7-dev2...v0.6.7-dev3
+
 ## v0.6.7-dev2
 
 ### 🚀 Features


### PR DESCRIPTION
## Summary

This PR fixes the serialization of autonomous tasks in agent operations to ensure proper JSON storage in the database.

## Changes

- **Fix**: Ensure proper serialization of `AgentAutonomous` objects using `model_dump()` before storing in database
- **Fix**: Correct task comparison logic in `delete_autonomous_task` to use direct attribute access
- **Doc**: Update changelog

## Details

The changes address two issues in the autonomous task management:

1. **Serialization Issue**: In both `add_autonomous_task` and `delete_autonomous_task` functions, `AgentAutonomous` objects weren't being properly serialized to dictionaries before storage in the database. This could cause JSON serialization errors.

2. **Task Comparison**: Fixed the task ID comparison logic in `delete_autonomous_task` to properly access the `id` attribute of `AgentAutonomous` objects.

## Files Changed

- `intentkit/core/agent.py`: Updated autonomous task management functions