### PR TITLE
chore: elfa v2 migration

### DIFF
--- a/intentkit/skills/elfa/README.md
+++ b/intentkit/skills/elfa/README.md
@@ -1,6 +1,12 @@
 # Elfa Skills - Social Media Intelligence
 
-Integration with [Elfa AI API](https://api.elfa.ai) providing real-time social media data analysis and processing capabilities for crypto and stock market sentiment tracking.
+Integration with [Elfa AI API v2](https://api.elfa.ai/v2) providing real-time social media data analysis and processing capabilities for crypto and stock market sentiment tracking.
+
+**Important: V2 API Changes**
+- **No Raw Content**: V2 API removes raw tweet content for platform compliance
+- **Sanitized Data**: Returns engagement metrics, timestamps, and account metadata only
+- **New Endpoints**: Updated endpoints with consistent response format
+- **Enhanced Pagination**: Different pagination patterns for search vs aggregation endpoints
 
 ## Setup
 
@@ -15,17 +21,24 @@ ELFA_API_KEY=your_elfa_api_key_here
 
 Ranks the most discussed tokens based on smart mentions count for a given period, updated every 5 minutes.
 
+**Endpoint**: `v2/aggregations/trending-tokens` - Direct Migration
+
 **Example Prompts:**
 ```
 "What are the trending crypto tokens in the last 24 hours?"
-"Show me the most discussed tokens today with at least 10 mentions"
-"Get trending tokens for the past week"
-"Which tokens are gaining attention on social media?"
+"Get trending tokens with minimum 50 mentions in the past week"
 ```
 
 **Parameters:**
-- `timeWindow`: "1h", "24h", "7d" (default: "24h")
+- `timeWindow`: "30m", "1h", "4h", "24h", "7d", "30d" (default: "7d")
+- `page`: Page number for pagination (default: 1)
+- `pageSize`: Number of items per page (default: 50)
 - `minMentions`: Minimum mentions required (default: 5)
+
+**V2 Changes:**
+- Same functionality and parameters
+- Enhanced response format with metadata
+- Uses page+pageSize pagination for aggregations
 
 ---
 
@@ -33,68 +46,107 @@ Ranks the most discussed tokens based on smart mentions count for a given period
 
 Queries tweets mentioning a specific stock/crypto ticker, ranked by view count for market sentiment analysis.
 
+**Endpoint**: `v2/data/top-mentions` - Breaking Changes
+
 **Example Prompts:**
 ```
 "Get the top mentions for Bitcoin in the last 24 hours"
-"Show me the most viewed tweets about $ETH today"
-"What are people saying about TSLA stock on Twitter?"
-"Find viral tweets mentioning $SOL with account details"
+"Show me engagement metrics for tweets about $ETH today"
 ```
 
 **Parameters:**
-- `ticker`: Stock/crypto symbol (e.g., "BTC", "$ETH", "AAPL")
-- `timeWindow`: "24h", "7d" (default: "24h") 
-- `includeAccountDetails`: Include account info (default: false)
+- `ticker`: Stock/crypto symbol (e.g., "BTC", "$ETH", "AAPL") - required
+- `timeWindow`: "1h", "24h", "7d" (default: "1h")
+- `page`: Page number for pagination (default: 1)
+- `pageSize`: Number of items per page (default: 10)
+
+**V2 Changes:**
+- **Removed**: Raw tweet content/text
+- **Removed**: `includeAccountDetails` parameter (always included)
+- **Preserved**: Engagement metrics (view_count, like_count, etc.)
+- **Preserved**: Account information and verification status
+- **Enhanced**: Account tags (e.g., "smart" accounts)
 
 ---
 
 ### 3. Search Mentions (`search_mentions`)
 
-Searches tweets mentioning up to 5 keywords. Can access 30 days of recent data (updated every 5 minutes) or 6 months of historical data.
+Searches tweets mentioning up to 5 keywords or from specific accounts with sanitized engagement data.
+
+**Endpoint**: `v2/data/keyword-mentions` - Breaking Changes
 
 **Example Prompts:**
 ```
-"Search for tweets mentioning 'DeFi, NFT, blockchain'"
-"Find recent mentions of 'AI, artificial intelligence, machine learning'"
-"Search historical tweets about 'bitcoin, cryptocurrency' from last month"
-"Look for discussions about 'climate change, renewable energy'"
+"Search for engagement metrics of tweets mentioning 'DeFi, NFT, blockchain'"
+"Find tweets from account 'elonmusk' about cryptocurrency"
 ```
 
 **Parameters:**
-- `keywords`: Up to 5 keywords (comma-separated, phrases accepted)
-- `from_`: Start timestamp (default: 24 hours ago)
-- `to`: End timestamp (default: yesterday)
+- `keywords`: Up to 5 keywords (comma-separated, phrases accepted) - optional if accountName provided
+- `accountName`: Account username to filter by - optional if keywords provided  
+- `timeWindow`: Time window for search (default: "7d")
+- `limit`: Number of results to return, max 30 (default: 20)
+- `searchType`: Type of search - "and" or "or" (default: "or")
+- `cursor`: Cursor for pagination (optional)
+
+**V2 Changes:**
+- **Removed**: Raw tweet content/text
+- **Preserved**: Engagement metrics and sentiment analysis
+- **Enhanced**: Account filtering with `accountName` parameter
+- **Updated**: Uses limit+cursor pagination for search
+- **Added**: Account tags and metadata
 
 ---
 
-### 4. Get Mentions (`get_mentions`)
-
-Retrieves hourly-updated tweets from "smart accounts" (influential accounts) that have received at least 10 interactions.
-
-**Example Prompts:**
-```
-"Get the latest mentions from smart accounts"
-"Show me recent tweets from influential crypto accounts"
-"What are the smart accounts talking about?"
-"Get the latest buzz from verified influencers"
-```
-
-**Parameters:** None (uses default limits)
-
----
-
-### 5. Get Smart Stats (`get_smart_stats`)
+### 4. Get Smart Stats (`get_smart_stats`)
 
 Retrieves key social media metrics for a specific username including engagement ratios and smart following count.
+
+**Endpoint**: `v2/account/smart-stats` - Direct Migration
 
 **Example Prompts:**
 ```
 "Get smart stats for @elonmusk"
 "Analyze the social metrics for username 'VitalikButerin'"
-"Show me engagement stats for @cz_binance"
-"What are the social media metrics for @jack?"
 ```
 
 **Parameters:**
-- `username`: Twitter username (with or without @)
+- `username`: Twitter username (with or without @) - required
+
+**V2 Changes:**
+- Same functionality and parameters
+- Consistent response format with metadata
+
+## V2 Response Format
+
+All V2 endpoints return a consistent format:
+
+```json
+{
+  "success": boolean,
+  "data": [...], // Array or object with actual data
+  "metadata": {  // Pagination and additional info
+    "total": number,
+    "page": number,
+    "pageSize": number,
+    "cursor": "string" // For search endpoints
+  }
+}
+```
+
+## Migration Notes
+
+### What's Removed in V2:
+- Raw tweet content/text (compliance requirement)
+- Direct access to tweet body/message content
+- `includeAccountDetails` parameter (always included)
+- **Deprecated**: `get_mentions` skill (no v2 equivalent)
+
+### What's Preserved:
+- Engagement metrics (likes, views, reposts, replies)
+- Account information and verification status
+- Timestamps and metadata
+- Sentiment analysis
+- Core functionality for trend analysis
+
 

--- a/intentkit/skills/elfa/__init__.py
+++ b/intentkit/skills/elfa/__init__.py
@@ -7,7 +7,6 @@ from intentkit.abstracts.skill import SkillStoreABC
 from intentkit.skills.base import SkillConfig, SkillState
 from intentkit.skills.elfa.base import ElfaBaseTool
 from intentkit.skills.elfa.mention import (
-    ElfaGetMentions,
     ElfaGetTopMentions,
     ElfaSearchMentions,
 )
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class SkillStates(TypedDict):
-    get_mentions: SkillState
     get_top_mentions: SkillState
     search_mentions: SkillState
     get_trending_tokens: SkillState
@@ -83,14 +81,7 @@ def get_elfa_skill(
         The requested Elfa skill
     """
 
-    if name == "get_mentions":
-        if name not in _cache:
-            _cache[name] = ElfaGetMentions(
-                skill_store=store,
-            )
-        return _cache[name]
-
-    elif name == "get_top_mentions":
+    if name == "get_top_mentions":
         if name not in _cache:
             _cache[name] = ElfaGetTopMentions(
                 skill_store=store,

--- a/intentkit/skills/elfa/base.py
+++ b/intentkit/skills/elfa/base.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 from intentkit.abstracts.skill import SkillStoreABC
 from intentkit.skills.base import IntentKitSkill, SkillContext
 
-base_url = "https://api.elfa.ai"
+base_url = "https://api.elfa.ai/v2"
 
 
 class ElfaBaseTool(IntentKitSkill):

--- a/intentkit/skills/elfa/mention.py
+++ b/intentkit/skills/elfa/mention.py
@@ -1,504 +1,223 @@
-import datetime
-import time
-from typing import Type
+"""Mention-related skills for Elfa AI API."""
 
-import httpx
-from langchain.tools.base import ToolException
+from typing import Any, Dict, List, Optional, Type
+
 from langchain_core.runnables import RunnableConfig
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field
 
-from .base import ElfaBaseTool, base_url
-
-
-def get_current_epoch_timestamp() -> int:
-    """Returns the current epoch timestamp (seconds since 1970-01-01 UTC)."""
-    return int(time.time())
-
-
-def get_yesterday_epoch_timestamp() -> int:
-    """Returns the epoch timestamp for yesterday (beginning of yesterday in UTC)."""
-    yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    # Combine with midnight time to get beginning of yesterday
-    yesterday_midnight = datetime.datetime.combine(yesterday, datetime.time.min)
-    # Convert to UTC
-    yesterday_midnight_utc = yesterday_midnight.replace(tzinfo=datetime.timezone.utc)
-    return int(yesterday_midnight_utc.timestamp())
-
-
-class ElfaGetMentionsInput(BaseModel):
-    pass
-
-
-class MediaUrl(BaseModel):
-    url: str | None = Field(None, description="Media URL")
-    type: str | None = Field(None, description="Media type")
-
-
-class AccountData(BaseModel):
-    name: str | None = Field(None, description="the name of the account")
-    location: str | None = Field(
-        None, description="the geographical location of the user account"
-    )
-    userSince: str | None = Field(None, description="account registration date")
-    description: str | None = Field(None, description="description of the account")
-    profileImageUrl: str | None = Field(None, description="url of the profile image")
-    profileBannerUrl: str | None = Field(
-        None, description="the url of the user profile banner"
-    )
-
-
-class Account(BaseModel):
-    id: int | None = Field(None, description="id of the account")
-    username: str | None = Field(None, description="username of the account")
-    data: AccountData | None = Field(
-        None, description="detailed information of the account"
-    )
-    followerCount: int | None = Field(
-        None, description="the total number of the followers"
-    )
-    followingCount: int | None = Field(
-        None, description="the total number of the followings"
-    )
-    isVerified: bool | None = Field(
-        None, description="whether is a verified account of Twitter or not"
-    )
-
-
-class TweetData(BaseModel):
-    mediaUrls: list[MediaUrl] | None = Field(
-        None, description="the URLs of the media files"
-    )
-
-
-class Tweet(BaseModel):
-    id: str | None = Field(None, description="Tweet ID")
-    type: str | None = Field(None, description="Tweet type")
-    content: str | None = Field(None, description="content of the Tweet")
-    originalUrl: str | None = Field(None, description="the original URL of the tweet")
-    data: TweetData | None = Field(None, description="the data of the Tweet")
-    likeCount: int | None = Field(None, description="number of times liked")
-    quoteCount: int | None = Field(None, description="content of the quoted")
-    replyCount: int | None = Field(None, description="number of times replied")
-    repostCount: int | None = Field(None, description="number of the reposts")
-    viewCount: int | None = Field(None, description="number of views")
-    mentionedAt: str | None = Field(
-        None, description="the time of getting mentioned by other accounts"
-    )
-    bookmarkCount: int | None = Field(None, description="number of times bookmarked")
-    account: Account | None = Field(None, description="the account information")
-    repliedToUser: str | None = Field(None, description="replied to user")
-    repliedToTweet: str | None = Field(None, description="replied to tweet")
-
-
-class ElfaGetMentionsOutput(BaseModel):
-    success: bool
-    data: list[Tweet] | None = Field(None, description="the list of tweets.")
-
-
-class ElfaGetMentions(ElfaBaseTool):
-    """
-    This tool uses the Elfa AI API to query hourly-updated tweets from "smart accounts" – accounts identified as influential or relevant – that have received at least 10 interactions (comments, retweets, quote tweets).
-
-    This tool is useful for:
-
-    * **Real-time Trend Analysis:**  Identify emerging trends and discussions as they happen.
-    * **Competitor Monitoring:** Track the social media activity of your competitors.
-    * **Influencer Tracking:** Monitor the conversations and content shared by key influencers.
-    * **Reputation Management:**  Identify and address potential PR issues.
-
-    The data returned includes the tweet content, timestamp, and potentially other relevant metadata.
-
-    Attributes:
-        name (str): Name of the tool, specifically "elfa_get_mentions".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
-    """
-
-    name: str = "elfa_get_mentions"
-    description: str = """This tool uses the Elfa AI API to query hourly-updated tweets from "smart accounts" – accounts identified as influential or relevant – that have received at least 10 interactions (comments, retweets, quote tweets).
-
-        This tool is useful for:
-
-        * **Real-time Trend Analysis:**  Identify emerging trends and discussions as they happen.
-        * **Competitor Monitoring:** Track the social media activity of your competitors.
-        * **Influencer Tracking:** Monitor the conversations and content shared by key influencers.
-        * **Reputation Management:**  Identify and address potential PR issues.
-
-        The data returned includes the tweet content, timestamp, and potentially other relevant metadata."""
-    args_schema: Type[BaseModel] = ElfaGetMentionsInput
-
-    async def _arun(
-        self, config: RunnableConfig = None, **kwargs
-    ) -> ElfaGetMentionsOutput:
-        """Run the tool to get the the ELFA AI API to query hourly-updated tweets from smart accounts with at least 10 interactions (comments, retweets, quote tweets).
-
-        Args:
-            config: The configuration for the runnable, containing agent context.
-            **kwargs: Additional parameters.
-
-        Returns:
-            ElfaGetMentionsOutput: A structured output containing output of Elfa get mentions API.
-
-        Raises:
-            Exception: If there's an error accessing the Elfa API.
-        """
-        context = self.context_from_config(config)
-        api_key = self.get_api_key(context)
-        if not api_key:
-            raise ValueError("Elfa API key not found")
-
-        url = f"{base_url}/v1/mentions"
-        headers = {
-            "accept": "application/json",
-            "x-elfa-api-key": api_key,
-        }
-
-        params = ElfaGetMentionsInput(limit=100, offset=0).model_dump(exclude_none=True)
-
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    url, headers=headers, timeout=30, params=params
-                )
-                response.raise_for_status()
-                json_dict = response.json()
-
-                res = ElfaGetMentionsOutput(**json_dict)
-
-                return res
-            except httpx.RequestError as req_err:
-                raise ToolException(
-                    f"request error from Elfa API: {req_err}"
-                ) from req_err
-            except httpx.HTTPStatusError as http_err:
-                raise ToolException(
-                    f"http error from Elfa API: {http_err}"
-                ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Elfa API: {e}") from e
+from .base import ElfaBaseTool
+from .utils import MentionData, make_elfa_request
 
 
 class ElfaGetTopMentionsInput(BaseModel):
+    """Input parameters for top mentions."""
+
     ticker: str = Field(description="Stock ticker symbol (e.g., ETH, $ETH, BTC, $BTC)")
-    timeWindow: str | None = Field("24h", description="Time window (e.g., 24h, 7d)")
-    includeAccountDetails: bool | None = Field(
-        False, description="Include account details"
+    timeWindow: Optional[str] = Field(
+        "1h", description="Time window (e.g., '1h', '24h', '7d')"
     )
-
-
-class TopMentionsPostMetrics(BaseModel):
-    like_count: int | None = Field(None, description="Number of likes for the post")
-    reply_count: int | None = Field(None, description="Number of replies for the post")
-    repost_count: int | None = Field(None, description="Number of reposts for the post")
-    view_count: int | None = Field(None, description="Number of views for the post")
-
-
-class TwitterAccountInfo(BaseModel):
-    username: str | None = Field(None, description="Twitter username")
-    twitter_user_id: str | None = Field(None, description="Twitter user ID")
-    description: str | None = Field(None, description="Twitter account description")
-    profileImageUrl: HttpUrl | None = Field(
-        None, description="URL of the profile image"
-    )
-
-
-class TopMentionsPostData(BaseModel):
-    id: int | None = Field(None, description="Unique ID of the post")
-    twitter_id: str | None = Field(None, description="Twitter ID of the post")
-    twitter_user_id: str | None = Field(
-        None, description="Twitter user ID of the poster"
-    )
-    content: str | None = Field(None, description="Content of the post")
-    mentioned_at: str | None = Field(
-        None, description="Timestamp when the post was mentioned"
-    )  # Consider using datetime if needed
-    type: str | None = Field(None, description="Type of the post (e.g., post, quote)")
-    metrics: TopMentionsPostMetrics | None = Field(
-        None, description="Metrics related to the post"
-    )
-    twitter_account_info: TwitterAccountInfo | None = Field(
-        None, description="Information about the Twitter account"
-    )
-
-
-class TopMentionsData(BaseModel):
-    data: list[TopMentionsPostData] | None = Field(
-        None, description="List of post data"
-    )
-    total: int | None = Field(None, description="Total number of posts")
-    page: int | None = Field(None, description="Current page number")
-    pageSize: int | None = Field(None, description="Number of posts per page")
+    page: Optional[int] = Field(1, description="Page number for pagination")
+    pageSize: Optional[int] = Field(10, description="Number of items per page")
 
 
 class ElfaGetTopMentionsOutput(BaseModel):
-    success: bool = Field(None, description="Indicates if the request was successful")
-    data: TopMentionsData | None = Field(None, description="Data returned by the API")
+    """Output structure for top mentions response."""
+
+    success: bool
+    data: Optional[List[MentionData]] = Field(None, description="List of top mentions")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Response metadata")
 
 
 class ElfaGetTopMentions(ElfaBaseTool):
     """
-    This tool uses the Elfa API to query tweets mentioning a specific stock ticker. The tweets are ranked by view count, providing insight into the most visible and potentially influential discussions surrounding the stock. The results are updated hourly, allowing for real-time monitoring of market sentiment.
+    Get top mentions for a specific ticker.
 
-    This tool is useful for:
+    This tool uses the Elfa API to query tweets mentioning a specific stock ticker.
+    The tweets are ranked by view count, providing insight into the most visible and
+    potentially influential discussions surrounding the stock. Results are updated hourly.
 
-    * **Real-time Sentiment Analysis:** Track changes in public opinion about a stock.
-    * **News Monitoring:** Identify trending news and discussions related to a specific ticker.
-    * **Investor Insights:** Monitor the conversations and opinions of investors and traders.
-
-    To use this tool, simply provide the stock ticker symbol (e.g., "AAPL", "TSLA"). The tool will return a list of tweets, ranked by view count.
-
-    Attributes:
-        name (str): Name of the tool, specifically "elfa_get_top_mentions".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
+    Use Cases:
+    - Real-time sentiment analysis: Track changes in public opinion about a stock
+    - News monitoring: Identify trending news and discussions related to a specific ticker
+    - Investor insights: Monitor conversations and opinions of investors and traders
     """
 
     name: str = "elfa_get_top_mentions"
-    description: str = """This tool uses the Elfa API to query tweets mentioning a specific stock ticker. The tweets are ranked by view count, providing insight into the most visible and potentially influential discussions surrounding the stock. The results are updated hourly, allowing for real-time monitoring of market sentiment.
-
-        This tool is useful for:
-
-        * **Real-time Sentiment Analysis:** Track changes in public opinion about a stock.
-        * **News Monitoring:** Identify trending news and discussions related to a specific ticker.
-        * **Investor Insights:** Monitor the conversations and opinions of investors and traders.
-
-        To use this tool, simply provide the stock ticker symbol (e.g., "AAPL", "TSLA"). The tool will return a list of tweets, ranked by view count."""
+    description: str = """Get top mentions for a specific ticker symbol ranked by view count. 
+    Updated hourly. Returns engagement metrics and account information for market sentiment analysis.
+    
+    Use this to track public opinion, identify trending news, and monitor investor discussions."""
     args_schema: Type[BaseModel] = ElfaGetTopMentionsInput
-
-    def _run(
-        self,
-        ticker: str,
-        timeWindow: str = "24h",
-        includeAccountDetails: bool = False,
-    ) -> ElfaGetTopMentionsOutput:
-        """Run the tool to get the Elfa API to query tweets mentioning a specific stock ticker. The tweets are ranked by view count and the results are updated hourly.
-
-        Returns:
-             ElfaAskOutput: A structured output containing output of Elfa top mentions API.
-
-        Raises:
-            Exception: If there's an error accessing the Elfa API.
-        """
-        raise NotImplementedError("Use _arun instead")
 
     async def _arun(
         self,
         ticker: str,
-        timeWindow: str = "24h",
-        includeAccountDetails: bool = False,
+        timeWindow: str = "1h",
+        page: int = 1,
+        pageSize: int = 10,
         config: RunnableConfig = None,
         **kwargs,
     ) -> ElfaGetTopMentionsOutput:
-        """Run the tool to get the Elfa API to query tweets mentioning a specific stock ticker. The tweets are ranked by view count and the results are updated hourly.
+        """
+        Execute the top mentions request.
 
         Args:
-            ticker: Stock ticker symbol.
-            timeWindow: Time window (optional).
-            includeAccountDetails: Include account details.
-            config: The configuration for the runnable, containing agent context.
-            **kwargs: Additional parameters.
+            ticker: Stock ticker symbol
+            timeWindow: Time window for mentions (default: 1h)
+            page: Page number for pagination (default: 1)
+            pageSize: Items per page (default: 10)
+            config: LangChain runnable configuration
+            **kwargs: Additional parameters
 
         Returns:
-            ElfaGetTopMentionsOutput: A structured output containing output of Elfa top mentions API.
+            ElfaGetTopMentionsOutput: Structured response with top mentions
 
         Raises:
-            Exception: If there's an error accessing the Elfa API.
+            ValueError: If API key is not found
+            ToolException: If there's an error with the API request
         """
         context = self.context_from_config(config)
         api_key = self.get_api_key(context)
-        if not api_key:
-            raise ValueError("Elfa API key not found")
 
-        url = f"{base_url}/v1/top-mentions"
-        headers = {
-            "accept": "application/json",
-            "x-elfa-api-key": api_key,
+        # Prepare parameters according to API spec
+        params = {
+            "ticker": ticker,
+            "timeWindow": timeWindow,
+            "page": page,
+            "pageSize": pageSize,
         }
 
-        params = ElfaGetTopMentionsInput(
-            ticker=ticker,
-            timeWindow=timeWindow,
-            page=1,
-            pageSize=20,
-            includeAccountDetails=includeAccountDetails,
-        ).model_dump(exclude_none=True)
+        # Make API request using shared utility
+        response = await make_elfa_request(
+            endpoint="data/top-mentions", api_key=api_key, params=params
+        )
 
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    url, headers=headers, timeout=30, params=params
-                )
-                response.raise_for_status()
-                json_dict = response.json()
+        # Parse response data into MentionData objects
+        mentions = []
+        if response.data and isinstance(response.data, list):
+            mentions = [MentionData(**item) for item in response.data]
 
-                res = ElfaGetTopMentionsOutput(**json_dict)
-
-                return res
-            except httpx.RequestError as req_err:
-                raise ToolException(
-                    f"request error from Elfa API: {req_err}"
-                ) from req_err
-            except httpx.HTTPStatusError as http_err:
-                raise ToolException(
-                    f"http error from Elfa API: {http_err}"
-                ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Elfa API: {e}") from e
+        return ElfaGetTopMentionsOutput(
+            success=response.success, data=mentions, metadata=response.metadata
+        )
 
 
 class ElfaSearchMentionsInput(BaseModel):
-    keywords: str = Field(
-        description="Up to 5 keywords to search for, separated by commas. Phrases accepted"
-    )
-    from_: int | None = Field(
-        None, description="Start date (unix timestamp), set default as 24 hours ago"
-    )
-    to: int | None = Field(
-        None, description="End date (unix timestamp), set default as now"
-    )
+    """Input parameters for search mentions."""
 
-
-class SearchMentionsPostMetrics(BaseModel):
-    like_count: int | None = Field(None, description="Number of likes for the post")
-    reply_count: int | None = Field(None, description="Number of replies for the post")
-    repost_count: int | None = Field(None, description="Number of reposts for the post")
-    view_count: int | None = Field(None, description="Number of views for the post")
-
-
-class SearchMentionsPostData(BaseModel):
-    id: int | None = Field(None, description="Unique ID of the post")
-    twitter_id: str | None = Field(None, description="Twitter ID of the post")
-    twitter_user_id: str | None = Field(
-        None, description="Twitter user ID of the poster"
+    keywords: Optional[str] = Field(
+        None,
+        description="Up to 5 keywords to search for, separated by commas. Phrases accepted",
     )
-    content: str | None = Field(None, description="Content of the post")
-    mentioned_at: str | None = Field(
-        None, description="Timestamp when the post was mentioned"
+    accountName: Optional[str] = Field(
+        None,
+        description="Account username to filter by (optional if keywords provided)",
     )
-    type: str | None = Field(
-        None, description="Type of the post (e.g., post, quote, repost)"
+    timeWindow: Optional[str] = Field("7d", description="Time window for search")
+    limit: Optional[int] = Field(20, description="Number of results to return (max 30)")
+    searchType: Optional[str] = Field(
+        "or", description="Type of search ('and' or 'or')"
     )
-    metrics: SearchMentionsPostMetrics | None = Field(
-        None, description="Metrics related to the post"
-    )
-    sentiment: str | None = Field(
-        None, description="Sentiment of the post (e.g., positive, negative, neutral)"
-    )
+    cursor: Optional[str] = Field(None, description="Cursor for pagination")
 
 
 class ElfaSearchMentionsOutput(BaseModel):
-    success: bool | None
-    data: list[SearchMentionsPostData] | None = Field(
-        None, description="the list of tweets."
+    """Output structure for search mentions response."""
+
+    success: bool
+    data: Optional[List[MentionData]] = Field(
+        None, description="List of matching mentions"
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None, description="Response metadata with cursor"
     )
 
 
 class ElfaSearchMentions(ElfaBaseTool):
     """
-    This tool uses the Elfa API to search tweets mentioning up to five keywords.  It can search within the past 30 days of data, which is updated every 5 minutes, or access up to six months of historical tweet data.
+    Search mentions by keywords or account name.
 
-    This tool is useful for:
+    This tool uses the Elfa API to search tweets mentioning up to five keywords or from specific accounts.
+    It can search within the past 30 days of data (updated every 5 minutes) or access historical data.
+    Returns sanitized engagement metrics and sentiment data.
 
-    * **Market Research:**  Track conversations and sentiment around specific products or industries.
-    * **Brand Monitoring:** Monitor mentions of your brand and identify potential PR issues.
-    * **Public Opinion Tracking:** Analyze public opinion on various topics.
-    * **Competitive Analysis:**  See what people are saying about your competitors.
-
-    To use this tool, provide up to five keywords.  You can also specify whether you want to search recent or historical tweets.
-
-    Attributes:
-        name (str): Name of the tool, specifically "elfa_search_mentions".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
+    Use Cases:
+    - Market research: Track conversations and sentiment around specific products or industries
+    - Brand monitoring: Monitor mentions of your brand and identify potential PR issues
+    - Public opinion tracking: Analyze public opinion on various topics
+    - Competitive analysis: See what people are saying about your competitors
     """
 
     name: str = "elfa_search_mentions"
-    description: str = """This tool uses the Elfa API to search tweets mentioning up to five keywords.  It can search within the past 30 days of data, which is updated every 5 minutes, or access up to six months of historical tweet data.
-
-        This tool is useful for:
-
-        * **Market Research:**  Track conversations and sentiment around specific products or industries.
-        * **Brand Monitoring:** Monitor mentions of your brand and identify potential PR issues.
-        * **Public Opinion Tracking:** Analyze public opinion on various topics.
-        * **Competitive Analysis:**  See what people are saying about your competitors.
-
-        To use this tool, provide up to five keywords.  You can also specify whether you want to search recent or historical tweets."""
+    description: str = """Search tweets by keywords or account name with engagement data and sentiment analysis. 
+    Updated every 5 minutes. Access 30 days of recent data or historical archives.
+    
+    Use this for market research, brand monitoring, opinion tracking, and competitive analysis."""
     args_schema: Type[BaseModel] = ElfaSearchMentionsInput
-
-    def _run(
-        self,
-        keywords: str,
-        from_: int = get_current_epoch_timestamp(),
-        to: int = get_yesterday_epoch_timestamp(),
-    ) -> ElfaSearchMentionsOutput:
-        """Run the tool to for tweets mentioning up to five keywords within the past 30 days.  It can access up to six months of historical tweet data, updated every five minutes via the Elfa API.
-
-        Returns:
-             ElfaAskOutput: A structured output containing output of Elfa top mentions API.
-
-        Raises:
-            Exception: If there's an error accessing the Elfa API.
-        """
-        raise NotImplementedError("Use _arun instead")
 
     async def _arun(
         self,
-        keywords: str,
-        from_: int = get_current_epoch_timestamp(),
-        to: int = get_yesterday_epoch_timestamp(),
+        keywords: Optional[str] = None,
+        accountName: Optional[str] = None,
+        timeWindow: str = "7d",
+        limit: int = 20,
+        searchType: str = "or",
+        cursor: Optional[str] = None,
         config: RunnableConfig = None,
         **kwargs,
     ) -> ElfaSearchMentionsOutput:
-        """Run the tool to for tweets mentioning up to five keywords within the past 30 days.  It can access up to six months of historical tweet data, updated every five minutes via the Elfa API.
+        """
+        Execute the search mentions request.
 
         Args:
-            keywords: Keywords to search.
-            from_: Start date (Unix timestamp).
-            to: End date (Unix timestamp).
-            config: The configuration for the runnable, containing agent context.
-            **kwargs: Additional parameters.
+            keywords: Keywords to search for (optional if accountName provided)
+            accountName: Account username to filter by (optional if keywords provided)
+            timeWindow: Time window for search (default: 7d)
+            limit: Number of results to return (default: 20, max 30)
+            searchType: Type of search - 'and' or 'or' (default: 'or')
+            cursor: Pagination cursor (optional)
+            config: LangChain runnable configuration
+            **kwargs: Additional parameters
 
         Returns:
-            ElfaSearchMentionsOutput: A structured output containing output of Elfa top mentions API.
+            ElfaSearchMentionsOutput: Structured response with matching mentions
 
         Raises:
-            Exception: If there's an error accessing the Elfa API.
+            ValueError: If API key is not found or neither keywords nor accountName provided
+            ToolException: If there's an error with the API request
         """
         context = self.context_from_config(config)
         api_key = self.get_api_key(context)
-        if not api_key:
-            raise ValueError("Elfa API key not found")
 
-        url = f"{base_url}/v1/mentions/search"
-        headers = {
-            "accept": "application/json",
-            "x-elfa-api-key": api_key,
+        # Validate that at least one search criteria is provided
+        if not keywords and not accountName:
+            raise ValueError("Either keywords or accountName must be provided")
+
+        # Prepare parameters according to API spec
+        params = {
+            "timeWindow": timeWindow,
+            "limit": min(limit, 30),  # API max is 30
+            "searchType": searchType,
         }
 
-        params = ElfaSearchMentionsInput(
-            keywords=keywords,
-            from_=from_,
-            to=to,
-        ).model_dump(exclude_none=True)
+        # Add optional parameters
+        if keywords:
+            params["keywords"] = keywords
+        if accountName:
+            params["accountName"] = accountName
+        if cursor:
+            params["cursor"] = cursor
 
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    url, headers=headers, timeout=30, params=params
-                )
-                response.raise_for_status()
-                json_dict = response.json()
+        # Make API request using shared utility
+        response = await make_elfa_request(
+            endpoint="data/keyword-mentions", api_key=api_key, params=params
+        )
 
-                res = ElfaSearchMentionsOutput(**json_dict)
+        # Parse response data into MentionData objects
+        mentions = []
+        if response.data and isinstance(response.data, list):
+            mentions = [MentionData(**item) for item in response.data]
 
-                return res
-            except httpx.RequestError as req_err:
-                raise ToolException(
-                    f"request error from Elfa API: {req_err}"
-                ) from req_err
-            except httpx.HTTPStatusError as http_err:
-                raise ToolException(
-                    f"http error from Elfa API: {http_err}"
-                ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Elfa API: {e}") from e
+        return ElfaSearchMentionsOutput(
+            success=response.success, data=mentions, metadata=response.metadata
+        )

--- a/intentkit/skills/elfa/schema.json
+++ b/intentkit/skills/elfa/schema.json
@@ -18,22 +18,6 @@
     "states": {
       "type": "object",
       "properties": {
-        "get_mentions": {
-          "type": "string",
-          "title": "Get Mentions",
-          "enum": [
-            "disabled",
-            "public",
-            "private"
-          ],
-          "x-enum-title": [
-            "Disabled",
-            "Agent Owner + All Users",
-            "Agent Owner Only"
-          ],
-          "description": "This tool uses the Elfa AI API to query hourly-updated tweets from \"smart accounts\" \u2013 accounts identified as influential or relevant \u2013 that have received at least 10 interactions (comments, retweets, quote tweets).",
-          "default": "disabled"
-        },
         "get_top_mentions": {
           "type": "string",
           "title": "Get Top Mentions",
@@ -63,7 +47,7 @@
             "Agent Owner + All Users",
             "Agent Owner Only"
           ],
-          "description": "This tool uses the Elfa API to search tweets mentioning up to five keywords. It can search within the past 30 days of data, which is updated every 5 minutes, or access up to six months of historical tweet data.",
+          "description": "This tool uses the Elfa API to search tweets mentioning up to five keywords or from specific accounts. It can search within the past 30 days of data, which is updated every 5 minutes, or access up to six months of historical tweet data.",
           "default": "private"
         },
         "get_trending_tokens": {

--- a/intentkit/skills/elfa/stats.py
+++ b/intentkit/skills/elfa/stats.py
@@ -1,118 +1,85 @@
-from typing import Type
+"""Smart stats skill for Elfa AI API."""
 
-import httpx
-from langchain.tools.base import ToolException
+from typing import Any, Dict, Optional, Type
+
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from .base import ElfaBaseTool, base_url
+from .base import ElfaBaseTool
+from .utils import SmartStatsData, make_elfa_request
 
 
 class ElfaGetSmartStatsInput(BaseModel):
-    username: str = Field(description="username to get stats for")
+    """Input parameters for smart stats."""
 
-
-class SmartStatsData(BaseModel):
-    followerEngagementRatio: float | None = Field(
-        description="the ratio of engagement by followers"
-    )
-    averageEngagement: float | None = Field(
-        description="the average engagement of acount"
-    )
-    smartFollowingCount: float | None = Field(
-        description="the count of smart followings"
-    )
+    username: str = Field(description="Account username to get stats for")
 
 
 class ElfaGetSmartStatsOutput(BaseModel):
+    """Output structure for smart stats response."""
+
     success: bool
-    data: SmartStatsData | None = Field(None, description="The stats data")
+    data: Optional[SmartStatsData] = Field(None, description="Smart stats data")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Response metadata")
 
 
 class ElfaGetSmartStats(ElfaBaseTool):
     """
-    This tool uses the Elfa API to retrieve key social media metrics for a given username.  These metrics include:
+    Get smart stats for a specific username.
 
-    * **Smart Following Count:** A metric representing the number of high-quality or influential followers.
-    * **Engagement Score:** A composite score reflecting the level of interaction with the user's content.
-    * **Engagement Ratio:** The ratio of engagement (likes, comments, shares) to the number of followers.
+    This tool uses the Elfa API to retrieve key social media metrics for a given username including:
+    - Smart Following Count: Number of high-quality or influential followers
+    - Average Engagement: Composite score reflecting interaction with user's content
+    - Average Reach: Average reach of the user's content
+    - Smart Follower Count: Number of smart followers
+    - Follower Count: Total follower count
 
-    This tool is useful for:
-
-    * **Competitor Analysis:** Compare your social media performance to that of your competitors.
-    * **Influencer Identification:** Identify influential users in your niche.
-    * **Social Media Audits:**  Assess the overall health and effectiveness of a social media presence.
-
-    To use this tool, simply provide the desired username.  The tool will return the requested metrics.
-
-    Attributes:
-        name (str): Name of the tool, specifically "elfa_get_smart_stats".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
+    Use Cases:
+    - Competitor analysis: Compare social media performance to competitors
+    - Influencer identification: Identify influential users in your niche
+    - Social media audits: Assess overall health and effectiveness of social media presence
     """
 
     name: str = "elfa_get_smart_stats"
-    description: str = """This tool uses the Elfa API to retrieve key social media metrics for a given username.  These metrics include:
-
-        * **Smart Following Count:** A metric representing the number of high-quality or influential followers.
-        * **Engagement Score:** A composite score reflecting the level of interaction with the user's content.
-        * **Engagement Ratio:** The ratio of engagement (likes, comments, shares) to the number of followers.
-
-        This tool is useful for:
-
-        * **Competitor Analysis:** Compare your social media performance to that of your competitors.
-        * **Influencer Identification:** Identify influential users in your niche.
-        * **Social Media Audits:**  Assess the overall health and effectiveness of a social media presence.
-        """
+    description: str = """Get comprehensive social media metrics for a username including smart following count, 
+    engagement scores, and follower analytics. Use this for competitor analysis, influencer identification, 
+    and social media performance audits."""
     args_schema: Type[BaseModel] = ElfaGetSmartStatsInput
 
     async def _arun(
-        self, username: str, config: RunnableConfig, **kwargs
+        self, username: str, config: RunnableConfig = None, **kwargs
     ) -> ElfaGetSmartStatsOutput:
-        """Run the tool retrieve smart stats (smart following count) and social metrics (engagement score and ratio) for a given username.
+        """
+        Execute the smart stats request.
 
         Args:
-            username (str): The username to check stats for.
-            config: The configuration for the runnable, containing agent context.
-            **kwargs: Additional parameters.
+            username: The username to check stats for
+            config: LangChain runnable configuration
+            **kwargs: Additional parameters
 
         Returns:
-            ElfaGetSmartStatsOutput: A structured output containing output of Elfa get mentions API.
+            ElfaGetSmartStatsOutput: Structured response with smart stats
 
         Raises:
-            Exception: If there's an error accessing the Elfa API.
+            ValueError: If API key is not found
+            ToolException: If there's an error with the API request
         """
         context = self.context_from_config(config)
         api_key = self.get_api_key(context)
-        if not api_key:
-            raise ValueError("Elfa API key not found")
 
-        url = f"{base_url}/v1/account/smart-stats"
-        headers = {
-            "accept": "application/json",
-            "x-elfa-api-key": api_key,
-        }
+        # Prepare parameters according to API spec
+        params = {"username": username}
 
-        params = ElfaGetSmartStatsInput(username=username).model_dump(exclude_none=True)
+        # Make API request using shared utility
+        response = await make_elfa_request(
+            endpoint="account/smart-stats", api_key=api_key, params=params
+        )
 
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    url, headers=headers, timeout=30, params=params
-                )
-                response.raise_for_status()
-                json_dict = response.json()
+        # Parse response data into SmartStatsData object
+        stats_data = None
+        if response.data and isinstance(response.data, dict):
+            stats_data = SmartStatsData(**response.data)
 
-                res = ElfaGetSmartStatsOutput(**json_dict)
-
-                return res
-            except httpx.RequestError as req_err:
-                raise ToolException(
-                    f"request error from Elfa API: {req_err}"
-                ) from req_err
-            except httpx.HTTPStatusError as http_err:
-                raise ToolException(
-                    f"http error from Elfa API: {http_err}"
-                ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Elfa API: {e}") from e
+        return ElfaGetSmartStatsOutput(
+            success=response.success, data=stats_data, metadata=response.metadata
+        )

--- a/intentkit/skills/elfa/utils.py
+++ b/intentkit/skills/elfa/utils.py
@@ -1,0 +1,129 @@
+"""Utility functions for Elfa skills."""
+
+from typing import Any, Dict, Optional
+
+import httpx
+from langchain.tools.base import ToolException
+from pydantic import BaseModel, Field
+
+from .base import base_url
+
+
+class ElfaResponse(BaseModel):
+    """Standard Elfa API v2 response format."""
+
+    success: bool
+    data: Any = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+async def make_elfa_request(
+    endpoint: str,
+    api_key: str,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: int = 30,
+) -> ElfaResponse:
+    """
+    Make a standardized request to the Elfa API.
+
+    Args:
+        endpoint: API endpoint path (e.g., "aggregations/trending-tokens")
+        api_key: Elfa API key
+        params: Query parameters
+        timeout: Request timeout in seconds
+
+    Returns:
+        ElfaResponse: Standardized response object
+
+    Raises:
+        ToolException: If there's an error with the API request
+    """
+    if not api_key:
+        raise ValueError("Elfa API key not found")
+
+    url = f"{base_url}/{endpoint}"
+    headers = {
+        "accept": "application/json",
+        "x-elfa-api-key": api_key,
+    }
+
+    # Clean up params - remove None values
+    if params:
+        params = {k: v for k, v in params.items() if v is not None}
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                url, headers=headers, timeout=timeout, params=params
+            )
+            response.raise_for_status()
+            json_dict = response.json()
+
+            # Handle v2 response format
+            if isinstance(json_dict, dict) and "success" in json_dict:
+                return ElfaResponse(
+                    success=json_dict["success"],
+                    data=json_dict.get("data"),
+                    metadata=json_dict.get("metadata", {}),
+                )
+            else:
+                # Fallback for unexpected format
+                return ElfaResponse(success=True, data=json_dict, metadata={})
+
+        except httpx.RequestError as req_err:
+            raise ToolException(f"Request error from Elfa API: {req_err}") from req_err
+        except httpx.HTTPStatusError as http_err:
+            raise ToolException(f"HTTP error from Elfa API: {http_err}") from http_err
+        except Exception as e:
+            raise ToolException(f"Error from Elfa API: {e}") from e
+
+
+# Common Pydantic models for v2 API responses
+class RepostBreakdown(BaseModel):
+    """Repost breakdown data."""
+
+    smart: Optional[int] = None
+    ct: Optional[int] = None
+
+
+class Account(BaseModel):
+    """Account information."""
+
+    username: Optional[str] = None
+    isVerified: Optional[bool] = None
+
+
+class MentionData(BaseModel):
+    """Base mention data structure used across multiple endpoints."""
+
+    tweetId: Optional[str] = Field(None, description="Tweet ID")
+    link: Optional[str] = Field(None, description="Link to the tweet")
+    likeCount: Optional[int] = Field(None, description="Number of likes")
+    repostCount: Optional[int] = Field(None, description="Number of reposts")
+    viewCount: Optional[int] = Field(None, description="Number of views")
+    quoteCount: Optional[int] = Field(None, description="Number of quotes")
+    replyCount: Optional[int] = Field(None, description="Number of replies")
+    bookmarkCount: Optional[int] = Field(None, description="Number of bookmarks")
+    mentionedAt: Optional[str] = Field(None, description="When mentioned")
+    type: Optional[str] = Field(None, description="Post type")
+    account: Optional[Account] = Field(None, description="Account information")
+    repostBreakdown: Optional[RepostBreakdown] = Field(
+        None, description="Repost breakdown"
+    )
+
+
+class SmartStatsData(BaseModel):
+    """Smart stats data structure."""
+
+    smartFollowingCount: Optional[int] = Field(
+        None, description="Smart following count"
+    )
+    averageEngagement: Optional[float] = Field(None, description="Average engagement")
+    averageReach: Optional[float] = Field(None, description="Average reach")
+    smartFollowerCount: Optional[int] = Field(None, description="Smart follower count")
+    followerCount: Optional[int] = Field(None, description="Total follower count")
+
+
+def clean_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None values from parameters dict."""
+    return {k: v for k, v in params.items() if v is not None}


### PR DESCRIPTION
## Description

migrated all Elfa skills to the v2 API. 

https://github.com/user-attachments/assets/16f4d849-fc5f-4fbc-a783-3a57fe04ec68




Key changes:
- Removed get_mentions skill (deprecated in v2)
- Updated all endpoints and response formatting for v2 compliance
- Enhanced Code structure with shared utils and proper error handling
- Verified All remaining skills working correctly with v2

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Improvement
- [ ] Documentation Update

## Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

