### PR TITLE
fix: add missing xmtp schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v0.6.11-dev4
+
+## Changes
+
+### Features/Improvements
+- Removed the XMTP swap and price skills.
+- Refactored the CDP client for better maintainability.
+
+### Dependency Updates
+- Updated various other dependencies.
+
+## Full Diff
+
+[Compare v0.6.11-dev3...main](https://github.com/crestalnetwork/intentkit/compare/v0.6.11-dev3...main)
+
 # v0.6.11-dev3
 
 ## Changes

--- a/intentkit/skills/xmtp/schema.json
+++ b/intentkit/skills/xmtp/schema.json
@@ -36,6 +36,38 @@
                     ],
                     "description": "Create XMTP transaction requests for transferring ETH or ERC20 tokens on Base mainnet. Supports both native ETH transfers and ERC20 token transfers. Generates wallet_sendCalls transaction data that users can sign.",
                     "default": "disabled"
+                },
+                "xmtp_swap": {
+                    "type": "string",
+                    "title": "XMTP Swap",
+                    "enum": [
+                        "disabled",
+                        "public",
+                        "private"
+                    ],
+                    "x-enum-title": [
+                        "Disabled",
+                        "Agent Owner + All Users",
+                        "Agent Owner Only"
+                    ],
+                    "description": "Create XMTP transaction requests for swapping tokens on Base using CDP swap quote. Returns a wallet_sendCalls payload that can include an optional approval call and the swap call. Only supports base-mainnet and base-sepolia.",
+                    "default": "disabled"
+                },
+                "xmtp_get_swap_price": {
+                    "type": "string",
+                    "title": "XMTP Get Swap Price",
+                    "enum": [
+                        "disabled",
+                        "public",
+                        "private"
+                    ],
+                    "x-enum-title": [
+                        "Disabled",
+                        "Agent Owner + All Users",
+                        "Agent Owner Only"
+                    ],
+                    "description": "Get an indicative swap price/quote for token pair and amount on Base networks using CDP. Provides estimated output amounts for token swaps without creating transactions.",
+                    "default": "disabled"
                 }
             }
         }


### PR DESCRIPTION
This PR adds the missing XMTP swap and price skills to the schema.