### PR TITLE
feat: add error_type field to chat message model

### DIFF
--- a/intentkit/models/chat.py
+++ b/intentkit/models/chat.py
@@ -277,6 +277,10 @@ class ChatMessageTable(Base):
         Boolean,
         nullable=True,
     )
+    error_type = Column(
+        String,
+        nullable=True,
+    )
     created_at = Column(
         DateTime(timezone=True),
         nullable=False,
@@ -362,6 +366,10 @@ class ChatMessageCreate(BaseModel):
         Optional[bool],
         Field(None, description="Optional flag to enable super mode"),
     ]
+    error_type: Annotated[
+        Optional[SystemMessageType],
+        Field(None, description="Optional error type, used when author_type is system"),
+    ]
 
     async def save_in_session(self, db: AsyncSession) -> "ChatMessage":
         """Save the chat message to the database.
@@ -418,6 +426,7 @@ class ChatMessageCreate(BaseModel):
             reply_to=reply_to,
             message=message,
             time_cost=time_cost,
+            error_type=message_type,
         )
 
 


### PR DESCRIPTION
This PR adds an `error_type` field to the chat message model to support better error handling and categorization in system messages.

## Changes
- Added `error_type` column to `ChatMessageTable` database model
- Added `error_type` field to `ChatMessageCreate` Pydantic model
- Updated the model to properly handle error type assignment

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update