### PR TITLE
feat: dexscreener new skills

### DIFF
--- a/intentkit/skills/dexscreener/README.md
+++ b/intentkit/skills/dexscreener/README.md
@@ -1,0 +1,154 @@
+# DexScreener Skill
+
+The DexScreener skill provides integration with the DexScreener API to search for cryptocurrency token pairs and retrieve market data including prices, volume, liquidity, and other trading metrics.
+
+## Overview
+
+DexScreener is a popular platform for tracking decentralized exchange (DEX) trading pairs across multiple blockchain networks. This skill enables your agent to search for token information and provide users with real-time market data.
+
+## Skills Available
+
+### `search_token`
+
+Searches DexScreener for token pairs matching a query string. Supports searching by:
+
+- Token symbol (e.g., "WIF", "DOGE")
+- Token name (e.g., "Dogwifhat")
+- Token address (e.g., "0x...")
+- Exact ticker matching with "$" prefix (e.g., "$WIF")
+- Pair address
+
+**Parameters:**
+
+- `query` (required): The search query string
+- `sort_by` (optional): Sort results by "liquidity" (default) or "volume"
+- `volume_timeframe` (optional): When sorting by volume, use "24_hour" (default), "6_hour", "1_hour", or "5_minutes"
+
+### `get_pair_info`
+
+Retrieves detailed information about a specific trading pair using chain ID and pair address.
+
+**Parameters:**
+
+- `chain_id` (required): The blockchain chain ID (e.g., "ethereum", "solana", "bsc", "polygon", "arbitrum", "base", "avalanche")
+- `pair_address` (required): The trading pair contract address
+
+### `get_token_pairs`
+
+Finds all trading pairs for a specific token using chain ID and token address.
+
+**Parameters:**
+
+- `chain_id` (required): The blockchain chain ID
+- `token_address` (required): The token contract address
+
+### `get_tokens_info`
+
+Retrieves detailed trading pair information for multiple tokens at once (up to 30 tokens).
+
+**Parameters:**
+
+- `chain_id` (required): The blockchain chain ID
+- `token_addresses` (required): List of token contract addresses (maximum 30)
+
+## Configuration
+
+Add to your agent configuration:
+
+```yaml
+skills:
+  dexscreener:
+    enabled: true
+    states:
+      search_token: public # or "private" or "disabled"
+      get_pair_info: public # or "private" or "disabled"
+      get_token_pairs: public # or "private" or "disabled"
+      get_tokens_info: public # or "private" or "disabled"
+```
+
+## Example Prompts
+
+Here are some example prompts that will trigger the DexScreener skill:
+
+### Basic Token Search
+
+- "What's the current price of WIF?"
+- "Show me information about Dogwifhat token"
+- "Find trading pairs for PEPE"
+- "Search for Solana tokens with high volume"
+
+### Address-Based Search
+
+- "Get token info for address 0x1234567890abcdef1234567890abcdef12345678"
+- "Look up this token contract: 0xabc123..."
+- "Find pairs for token address 0x..."
+
+### Exact Ticker Matching
+
+- "Show me all $WIF pairs" (matches only tokens with symbol "WIF")
+- "Find $DOGE trading data"
+- "$SOL price and volume information"
+
+### Sorting and Filtering
+
+- "Find highest volume tokens in the last hour"
+- "Show me tokens sorted by liquidity"
+- "Get 6-hour volume data for trending tokens"
+
+### Market Analysis
+
+- "What are the most liquid trading pairs right now?"
+- "Find new token launches with high volume"
+- "Show me tokens with significant price changes in the last 24 hours"
+- "Compare liquidity across different DEXes for a token"
+
+### Specific Pair Analysis
+
+- "Get detailed info for pair address 0x1234... on Ethereum"
+- "Show me the liquidity and volume for this Uniswap pair"
+- "Analyze this specific trading pair on Solana"
+- "What's the current price and 24h change for pair 0xabc..."
+
+### Token Pair Discovery
+
+- "Find all trading pairs for token 0x1234... on Ethereum"
+- "Where can I trade this token? Show me all available pairs"
+- "List all DEXes that have liquidity for this token address"
+- "Find the best liquidity pools for token 0xabc..."
+
+### Multi-Token Analysis
+
+- "Compare these 5 token addresses: [list of addresses]"
+- "Get trading data for my entire portfolio: [token addresses]"
+- "Analyze liquidity across these tokens on Ethereum"
+- "Show me pair information for these 10 tokens at once"
+
+### Portfolio Research
+
+- "Research this token before I invest: [token name/symbol]"
+- "Is this token legitimate? Check its social links"
+- "What DEXes is this token trading on?"
+- "Show me the trading activity for this pair"
+
+## Response Format
+
+The skill returns structured JSON data containing:
+
+- Token pair information (base/quote tokens)
+- Current prices in USD and native currency
+- Volume data across different timeframes
+- Liquidity information
+- Price change percentages
+- Market cap and fully diluted valuation
+- Social links and website information
+- Trading transaction counts
+
+## Rate Limits
+
+- 300 requests per minute across all users
+- Built-in rate limiting prevents exceeding API limits
+- Requests are queued and processed efficiently
+
+## Data Sources
+
+All data is sourced from the official DexScreener API, which aggregates information from major decentralized exchanges across multiple blockchain networks including Ethereum, Solana, Binance Smart Chain, and others.

--- a/intentkit/skills/dexscreener/__init__.py
+++ b/intentkit/skills/dexscreener/__init__.py
@@ -4,6 +4,9 @@ from typing import Optional, TypedDict
 from intentkit.abstracts.skill import SkillStoreABC
 from intentkit.skills.base import SkillConfig, SkillState
 from intentkit.skills.dexscreener.base import DexScreenerBaseTool
+from intentkit.skills.dexscreener.get_pair_info import GetPairInfo
+from intentkit.skills.dexscreener.get_token_pairs import GetTokenPairs
+from intentkit.skills.dexscreener.get_tokens_info import GetTokensInfo
 from intentkit.skills.dexscreener.search_token import SearchToken
 
 # Cache skills at the system level, because they are stateless
@@ -14,10 +17,16 @@ logger = logging.getLogger(__name__)
 
 class SkillStates(TypedDict):
     search_token: SkillState
+    get_pair_info: SkillState
+    get_token_pairs: SkillState
+    get_tokens_info: SkillState
 
 
 _SKILL_NAME_TO_CLASS_MAP: dict[str, type[DexScreenerBaseTool]] = {
     "search_token": SearchToken,
+    "get_pair_info": GetPairInfo,
+    "get_token_pairs": GetTokenPairs,
+    "get_tokens_info": GetTokensInfo,
 }
 
 

--- a/intentkit/skills/dexscreener/base.py
+++ b/intentkit/skills/dexscreener/base.py
@@ -7,12 +7,9 @@ from pydantic import Field
 
 from intentkit.abstracts.skill import SkillStoreABC
 from intentkit.skills.base import IntentKitSkill
+from intentkit.skills.dexscreener.utils import DEXSCREENER_BASE_URL
 
 logger = logging.getLogger(__name__)
-
-DEXSCREENER_BASE_URL = "https://api.dexscreener.com"
-
-# Removed DexScreenerApiError as it won't be raised by _get anymore
 
 # ApiResult still represents (success_data, error_data)
 ApiResult = Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]

--- a/intentkit/skills/dexscreener/get_pair_info.py
+++ b/intentkit/skills/dexscreener/get_pair_info.py
@@ -1,0 +1,159 @@
+import logging
+from typing import Any, Type
+
+from pydantic import BaseModel, Field
+
+from intentkit.skills.dexscreener.base import DexScreenerBaseTool
+from intentkit.skills.dexscreener.model.search_token_response import PairModel
+from intentkit.skills.dexscreener.utils import (
+    API_ENDPOINTS,
+    RATE_LIMITS,
+    create_error_response,
+    format_success_response,
+    truncate_large_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GetPairInfoInput(BaseModel):
+    """Input schema for the DexScreener get_pair_info tool."""
+
+    chain_id: str = Field(
+        description="The blockchain chain ID (e.g., 'ethereum', 'solana', 'bsc', 'polygon', 'arbitrum', 'base', 'avalanche')"
+    )
+    pair_address: str = Field(
+        description="The trading pair contract address (e.g., '0x1234...abcd' for Ethereum-based chains)"
+    )
+
+
+class GetPairInfo(DexScreenerBaseTool):
+    """
+    Tool to get detailed information about a specific trading pair on DexScreener.
+    """
+
+    name: str = "dexscreener_get_pair_info"
+    description: str = (
+        "Retrieves detailed information about a specific trading pair using chain ID and pair address. "
+        "Returns comprehensive data including current price, volume, liquidity, price changes, "
+        "market cap, FDV, transaction counts, and social links. "
+        "Use this tool when you have a specific pair address and need detailed trading metrics."
+    )
+    args_schema: Type[BaseModel] = GetPairInfoInput
+
+    async def _arun(
+        self,
+        chain_id: str,
+        pair_address: str,
+        **kwargs: Any,
+    ) -> str:
+        """Implementation to get specific pair information."""
+
+        # Apply rate limiting
+        await self.user_rate_limit_by_category(
+            user_id=f"{self.category}{self.name}",
+            limit=RATE_LIMITS["pairs"],
+            minutes=1,
+        )
+
+        logger.info(
+            f"Executing DexScreener get_pair_info tool with chain_id: '{chain_id}', "
+            f"pair_address: '{pair_address}'"
+        )
+
+        try:
+            # Construct API path
+            api_path = f"{API_ENDPOINTS['pairs']}/{chain_id}/{pair_address}"
+
+            data, error_details = await self._get(path=api_path)
+
+            if error_details:
+                return await self._handle_error_response(error_details)
+
+            if not data:
+                logger.error(f"No data returned for pair {pair_address} on {chain_id}")
+                return create_error_response(
+                    error_type="empty_success",
+                    message="API call returned empty success response.",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "pair_address": pair_address,
+                    },
+                )
+
+            # The API returns a single pair object, not wrapped in a pairs array
+            if not isinstance(data, dict):
+                return create_error_response(
+                    error_type="format_error",
+                    message="Unexpected response format - expected object",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "pair_address": pair_address,
+                    },
+                )
+
+            try:
+                # Validate the response using our existing PairModel
+                pair_data = PairModel.model_validate(data)
+                logger.info(
+                    f"Successfully retrieved pair info for {pair_address} on {chain_id}"
+                )
+
+                return format_success_response(
+                    {
+                        "pair": pair_data.model_dump(),
+                        "chain_id": chain_id,
+                        "pair_address": pair_address,
+                    }
+                )
+
+            except Exception as validation_error:
+                logger.error(
+                    f"Failed to validate pair response for {pair_address} on {chain_id}: {validation_error}",
+                    exc_info=True,
+                )
+                # Return raw data if validation fails
+                return format_success_response(
+                    {
+                        "pair": data,
+                        "chain_id": chain_id,
+                        "pair_address": pair_address,
+                        "validation_warning": "Response structure may have changed",
+                    }
+                )
+
+        except Exception as e:
+            return await self._handle_unexpected_runtime_error(
+                e, f"{chain_id}/{pair_address}"
+            )
+
+    async def _handle_error_response(self, error_details: dict) -> str:
+        """Formats error details (from _get) into a JSON string."""
+        if error_details.get("error_type") in [
+            "connection_error",
+            "parsing_error",
+            "unexpected_error",
+        ]:
+            logger.error(
+                f"DexScreener get_pair_info tool encountered an error: {error_details}"
+            )
+        else:  # api_error
+            logger.warning(f"DexScreener API returned an error: {error_details}")
+
+        # Truncate potentially large fields before returning to user/LLM
+        truncated_details = truncate_large_fields(error_details)
+        return format_success_response(truncated_details)
+
+    async def _handle_unexpected_runtime_error(
+        self, e: Exception, query_info: str
+    ) -> str:
+        """Formats unexpected runtime exception details into a JSON string."""
+        logger.exception(
+            f"An unexpected runtime error occurred in get_pair_info tool _arun method for {query_info}: {e}"
+        )
+        return create_error_response(
+            error_type="runtime_error",
+            message="An unexpected internal error occurred processing the pair info request",
+            details=str(e),
+            additional_data={"query_info": query_info},
+        )

--- a/intentkit/skills/dexscreener/get_token_pairs.py
+++ b/intentkit/skills/dexscreener/get_token_pairs.py
@@ -1,0 +1,166 @@
+import logging
+from typing import Any, Type
+
+from pydantic import BaseModel, Field, ValidationError
+
+from intentkit.skills.dexscreener.base import DexScreenerBaseTool
+from intentkit.skills.dexscreener.model.search_token_response import (
+    SearchTokenResponseModel,
+)
+from intentkit.skills.dexscreener.utils import (
+    API_ENDPOINTS,
+    RATE_LIMITS,
+    create_error_response,
+    create_no_results_response,
+    format_success_response,
+    get_liquidity_value,
+    handle_validation_error,
+    truncate_large_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GetTokenPairsInput(BaseModel):
+    """Input schema for the DexScreener get_token_pairs tool."""
+
+    chain_id: str = Field(
+        description="The blockchain chain ID (e.g., 'ethereum', 'solana', 'bsc', 'polygon', 'arbitrum', 'base', 'avalanche')"
+    )
+    token_address: str = Field(
+        description="The token contract address (e.g., '0x1234...abcd' for Ethereum-based chains)"
+    )
+
+
+class GetTokenPairs(DexScreenerBaseTool):
+    """
+    Tool to get all trading pairs for a specific token on DexScreener.
+    """
+
+    name: str = "dexscreener_get_token_pairs"
+    description: str = (
+        "Finds all trading pairs for a specific token using chain ID and token address. "
+        "Returns a list of all pools/pairs where this token is traded, including pair addresses, "
+        "DEX information, liquidity, volume, and pricing data for each pair. "
+        "Use this tool to analyze all available trading venues and liquidity sources for a specific token."
+    )
+    args_schema: Type[BaseModel] = GetTokenPairsInput
+
+    async def _arun(
+        self,
+        chain_id: str,
+        token_address: str,
+        **kwargs: Any,
+    ) -> str:
+        """Implementation to get all pairs for a specific token."""
+
+        # Apply rate limiting
+        await self.user_rate_limit_by_category(
+            user_id=f"{self.category}{self.name}",
+            limit=RATE_LIMITS["token_pairs"],
+            minutes=1,
+        )
+
+        logger.info(
+            f"Executing DexScreener get_token_pairs tool with chain_id: '{chain_id}', "
+            f"token_address: '{token_address}'"
+        )
+
+        try:
+            # Construct API path
+            api_path = f"{API_ENDPOINTS['token_pairs']}/{chain_id}/{token_address}"
+
+            data, error_details = await self._get(path=api_path)
+
+            if error_details:
+                return await self._handle_error_response(error_details)
+
+            if not data:
+                logger.error(
+                    f"No data returned for token {token_address} on {chain_id}"
+                )
+                return create_error_response(
+                    error_type="empty_success",
+                    message="API call returned empty success response.",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "token_address": token_address,
+                    },
+                )
+
+            try:
+                # Validate response using SearchTokenResponseModel since API returns similar structure
+                result = SearchTokenResponseModel.model_validate(data)
+            except ValidationError as e:
+                return handle_validation_error(
+                    e, f"{chain_id}/{token_address}", len(str(data))
+                )
+
+            if not result.pairs:
+                return create_no_results_response(
+                    f"{chain_id}/{token_address}",
+                    reason="no trading pairs found for this token",
+                )
+
+            pairs_list = [p for p in result.pairs if p is not None]
+
+            if not pairs_list:
+                return create_no_results_response(
+                    f"{chain_id}/{token_address}",
+                    reason="all pairs were null or invalid",
+                )
+
+            # Sort pairs by liquidity (highest first) for better UX
+            try:
+                pairs_list.sort(key=get_liquidity_value, reverse=True)
+            except Exception as sort_err:
+                logger.warning(f"Failed to sort pairs by liquidity: {sort_err}")
+
+            logger.info(
+                f"Found {len(pairs_list)} pairs for token {token_address} on {chain_id}"
+            )
+
+            return format_success_response(
+                {
+                    "pairs": [p.model_dump() for p in pairs_list],
+                    "chain_id": chain_id,
+                    "token_address": token_address,
+                    "total_pairs": len(pairs_list),
+                }
+            )
+
+        except Exception as e:
+            return await self._handle_unexpected_runtime_error(
+                e, f"{chain_id}/{token_address}"
+            )
+
+    async def _handle_error_response(self, error_details: dict) -> str:
+        """Formats error details (from _get) into a JSON string."""
+        if error_details.get("error_type") in [
+            "connection_error",
+            "parsing_error",
+            "unexpected_error",
+        ]:
+            logger.error(
+                f"DexScreener get_token_pairs tool encountered an error: {error_details}"
+            )
+        else:  # api_error
+            logger.warning(f"DexScreener API returned an error: {error_details}")
+
+        # Truncate potentially large fields before returning to user/LLM
+        truncated_details = truncate_large_fields(error_details)
+        return format_success_response(truncated_details)
+
+    async def _handle_unexpected_runtime_error(
+        self, e: Exception, query_info: str
+    ) -> str:
+        """Formats unexpected runtime exception details into a JSON string."""
+        logger.exception(
+            f"An unexpected runtime error occurred in get_token_pairs tool _arun method for {query_info}: {e}"
+        )
+        return create_error_response(
+            error_type="runtime_error",
+            message="An unexpected internal error occurred processing the token pairs request",
+            details=str(e),
+            additional_data={"query_info": query_info},
+        )

--- a/intentkit/skills/dexscreener/get_tokens_info.py
+++ b/intentkit/skills/dexscreener/get_tokens_info.py
@@ -1,0 +1,213 @@
+import logging
+from typing import Any, List, Type
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from intentkit.skills.dexscreener.base import DexScreenerBaseTool
+from intentkit.skills.dexscreener.model.search_token_response import (
+    SearchTokenResponseModel,
+)
+from intentkit.skills.dexscreener.utils import (
+    API_ENDPOINTS,
+    MAX_TOKENS_BATCH,
+    RATE_LIMITS,
+    create_error_response,
+    create_no_results_response,
+    format_success_response,
+    get_liquidity_value,
+    group_pairs_by_token,
+    handle_validation_error,
+    truncate_large_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GetTokensInfoInput(BaseModel):
+    """Input schema for the DexScreener get_tokens_info tool."""
+
+    chain_id: str = Field(
+        description="The blockchain chain ID (e.g., 'ethereum', 'solana', 'bsc', 'polygon', 'arbitrum', 'base', 'avalanche')"
+    )
+    token_addresses: List[str] = Field(
+        description=f"List of token contract addresses to retrieve info for (maximum {MAX_TOKENS_BATCH} addresses). "
+        "Each address should be in the format '0x1234...abcd' for Ethereum-based chains."
+    )
+
+    @field_validator("token_addresses")
+    @classmethod
+    def validate_token_addresses(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("At least one token address is required")
+        if len(v) > MAX_TOKENS_BATCH:
+            raise ValueError(f"Maximum {MAX_TOKENS_BATCH} token addresses allowed")
+        # Remove duplicates while preserving order
+        seen = set()
+        unique_addresses = []
+        for addr in v:
+            if addr not in seen:
+                seen.add(addr)
+                unique_addresses.append(addr)
+        return unique_addresses
+
+
+class GetTokensInfo(DexScreenerBaseTool):
+    """
+    Tool to get detailed information for multiple tokens at once on DexScreener.
+    """
+
+    name: str = "dexscreener_get_tokens_info"
+    description: str = (
+        f"Retrieves detailed trading pair information for multiple tokens (up to {MAX_TOKENS_BATCH}) "
+        "using chain ID and a list of token addresses. For each token, returns all available "
+        "trading pairs with price, volume, liquidity, market data, and DEX information. "
+        "This is more efficient than making individual calls when you need info for multiple tokens. "
+        "Use this tool for portfolio analysis or comparing multiple tokens at once."
+    )
+    args_schema: Type[BaseModel] = GetTokensInfoInput
+
+    async def _arun(
+        self,
+        chain_id: str,
+        token_addresses: List[str],
+        **kwargs: Any,
+    ) -> str:
+        """Implementation to get information for multiple tokens."""
+
+        # Apply rate limiting
+        await self.user_rate_limit_by_category(
+            user_id=f"{self.category}{self.name}",
+            limit=RATE_LIMITS["tokens"],
+            minutes=1,
+        )
+
+        logger.info(
+            f"Executing DexScreener get_tokens_info tool with chain_id: '{chain_id}', "
+            f"token_addresses: {len(token_addresses)} tokens"
+        )
+
+        try:
+            # Construct API path - addresses are comma-separated
+            addresses_param = ",".join(token_addresses)
+            api_path = f"{API_ENDPOINTS['tokens']}/{chain_id}/{addresses_param}"
+
+            data, error_details = await self._get(path=api_path)
+
+            if error_details:
+                return await self._handle_error_response(error_details)
+
+            if not data:
+                logger.error(f"No data returned for tokens on {chain_id}")
+                return create_error_response(
+                    error_type="empty_success",
+                    message="API call returned empty success response.",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "token_addresses": token_addresses,
+                    },
+                )
+
+            try:
+                # Validate response using SearchTokenResponseModel since API returns similar structure
+                result = SearchTokenResponseModel.model_validate(data)
+            except ValidationError as e:
+                return handle_validation_error(
+                    e, f"{chain_id}/{len(token_addresses)} tokens", len(str(data))
+                )
+
+            if not result.pairs:
+                return create_no_results_response(
+                    f"{chain_id} - {len(token_addresses)} tokens",
+                    reason="no trading pairs found for any of the specified tokens",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "requested_addresses": token_addresses,
+                        "tokens_data": {},
+                        "all_pairs": [],
+                        "found_tokens": 0,
+                        "total_pairs": 0,
+                    },
+                )
+
+            pairs_list = [p for p in result.pairs if p is not None]
+
+            if not pairs_list:
+                return create_no_results_response(
+                    f"{chain_id} - {len(token_addresses)} tokens",
+                    reason="all pairs were null or invalid",
+                    additional_data={
+                        "chain_id": chain_id,
+                        "requested_addresses": token_addresses,
+                        "tokens_data": {},
+                        "all_pairs": [],
+                        "found_tokens": 0,
+                        "total_pairs": 0,
+                    },
+                )
+
+            # Group pairs by token address for better organization
+            tokens_data = group_pairs_by_token(pairs_list)
+
+            # Sort pairs within each token by liquidity (highest first)
+            for token_addr, pairs in tokens_data.items():
+                try:
+                    pairs.sort(key=get_liquidity_value, reverse=True)
+                except Exception as sort_err:
+                    logger.warning(
+                        f"Failed to sort pairs for token {token_addr}: {sort_err}"
+                    )
+
+            logger.info(
+                f"Found {len(pairs_list)} total pairs across {len(tokens_data)} tokens "
+                f"for {len(token_addresses)} requested addresses on {chain_id}"
+            )
+
+            return format_success_response(
+                {
+                    "tokens_data": {
+                        addr: [p.model_dump() for p in pairs]
+                        for addr, pairs in tokens_data.items()
+                    },
+                    "all_pairs": [p.model_dump() for p in pairs_list],
+                    "chain_id": chain_id,
+                    "requested_addresses": token_addresses,
+                    "found_tokens": len(tokens_data),
+                    "total_pairs": len(pairs_list),
+                }
+            )
+
+        except Exception as e:
+            return await self._handle_unexpected_runtime_error(
+                e, f"{chain_id}/{len(token_addresses)} tokens"
+            )
+
+    async def _handle_error_response(self, error_details: dict) -> str:
+        """Formats error details (from _get) into a JSON string."""
+        if error_details.get("error_type") in [
+            "connection_error",
+            "parsing_error",
+            "unexpected_error",
+        ]:
+            logger.error(
+                f"DexScreener get_tokens_info tool encountered an error: {error_details}"
+            )
+        else:  # api_error
+            logger.warning(f"DexScreener API returned an error: {error_details}")
+
+        # Truncate potentially large fields before returning to user/LLM
+        truncated_details = truncate_large_fields(error_details)
+        return format_success_response(truncated_details)
+
+    async def _handle_unexpected_runtime_error(
+        self, e: Exception, query_info: str
+    ) -> str:
+        """Formats unexpected runtime exception details into a JSON string."""
+        logger.exception(
+            f"An unexpected runtime error occurred in get_tokens_info tool _arun method for {query_info}: {e}"
+        )
+        return create_error_response(
+            error_type="runtime_error",
+            message="An unexpected internal error occurred processing the tokens info request",
+            details=str(e),
+            additional_data={"query_info": query_info},
+        )

--- a/intentkit/skills/dexscreener/schema.json
+++ b/intentkit/skills/dexscreener/schema.json
@@ -34,7 +34,52 @@
                         "Agent Owner + All Users",
                         "Agent Owner Only"
                     ],
-                    "description": "Searches on DexScreener for token pairs matching a query (symbol, name, address). Returns up to 50 pairs sorted by 'liquidity' or 'volume24h' (required input), including price, volume, etc. Use this tool to find token information based on user queries.",
+                    "description": "Searches on DexScreener for token pairs matching a query (symbol, name, address). Returns up to 25 pairs sorted by 'liquidity' or 'volume' with timeframe options, including price, volume, etc. Use this tool to find token information based on user queries.",
+                    "default": "disabled"
+                },
+                "get_pair_info": {
+                    "type": "string",
+                    "enum": [
+                        "disabled",
+                        "public",
+                        "private"
+                    ],
+                    "x-enum-title": [
+                        "Disabled",
+                        "Agent Owner + All Users",
+                        "Agent Owner Only"
+                    ],
+                    "description": "Retrieves detailed information about a specific trading pair using chain ID and pair address. Returns comprehensive data including current price, volume, liquidity, price changes, market cap, FDV, transaction counts, and social links.",
+                    "default": "disabled"
+                },
+                "get_token_pairs": {
+                    "type": "string",
+                    "enum": [
+                        "disabled",
+                        "public",
+                        "private"
+                    ],
+                    "x-enum-title": [
+                        "Disabled",
+                        "Agent Owner + All Users",
+                        "Agent Owner Only"
+                    ],
+                    "description": "Finds all trading pairs for a specific token using chain ID and token address. Returns a list of all pools/pairs where this token is traded, including pair addresses, DEX information, liquidity, volume, and pricing data for each pair.",
+                    "default": "disabled"
+                },
+                "get_tokens_info": {
+                    "type": "string",
+                    "enum": [
+                        "disabled",
+                        "public",
+                        "private"
+                    ],
+                    "x-enum-title": [
+                        "Disabled",
+                        "Agent Owner + All Users",
+                        "Agent Owner Only"
+                    ],
+                    "description": "Retrieves detailed trading pair information for multiple tokens (up to 30) using chain ID and a list of token addresses. More efficient than making individual calls when you need info for multiple tokens. Use for portfolio analysis or comparing multiple tokens at once.",
                     "default": "disabled"
                 }
             }

--- a/intentkit/skills/dexscreener/utils.py
+++ b/intentkit/skills/dexscreener/utils.py
@@ -1,0 +1,419 @@
+"""
+Utility functions and constants for DexScreener skills.
+"""
+
+import json
+import logging
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import ValidationError
+
+from intentkit.skills.dexscreener.model.search_token_response import PairModel
+
+logger = logging.getLogger(__name__)
+
+# API Base URL
+DEXSCREENER_BASE_URL = "https://api.dexscreener.com"
+
+# API Endpoints
+API_ENDPOINTS = {
+    "search": "/latest/dex/search",
+    "pairs": "/latest/dex/pairs",
+    "token_pairs": "/token-pairs/v1",
+    "tokens": "/tokens/v1",
+    "token_profiles": "/token-profiles/latest/v1",
+    "token_boosts_latest": "/token-boosts/latest/v1",
+    "token_boosts_top": "/token-boosts/top/v1",
+    "orders": "/orders/v1",
+}
+
+# Rate Limits (requests per minute)
+RATE_LIMITS = {
+    "search": 300,
+    "pairs": 300,
+    "token_pairs": 300,
+    "tokens": 300,
+    "token_profiles": 60,
+    "token_boosts": 60,
+    "orders": 60,
+}
+
+# Limits
+MAX_SEARCH_RESULTS = 25
+MAX_TOKENS_BATCH = 30
+
+# Common disclaimer for search results
+SEARCH_DISCLAIMER = {
+    "disclaimer": (
+        "Search results may include unofficial, duplicate, or potentially malicious tokens. "
+        "If multiple unrelated tokens share a similar name or ticker, ask the user for the exact token address. "
+        "If the correct token is not found, re-run the tool using the provided address. "
+        "Also advise the user to verify the token's legitimacy via its official social links included in the result."
+    )
+}
+
+
+# Query Types
+class QueryType(str, Enum):
+    TEXT = "TEXT"
+    TICKER = "TICKER"
+    ADDRESS = "ADDRESS"
+
+
+# Sort Options
+class SortBy(str, Enum):
+    LIQUIDITY = "liquidity"
+    VOLUME = "volume"
+
+
+# Volume Timeframes
+class VolumeTimeframe(str, Enum):
+    FIVE_MINUTES = "5_minutes"
+    ONE_HOUR = "1_hour"
+    SIX_HOUR = "6_hour"
+    TWENTY_FOUR_HOUR = "24_hour"
+
+
+# Supported Chain IDs
+SUPPORTED_CHAINS = [
+    "ethereum",
+    "bsc",
+    "polygon",
+    "avalanche",
+    "fantom",
+    "cronos",
+    "arbitrum",
+    "optimism",
+    "base",
+    "solana",
+    "sui",
+    "tron",
+    "ton",
+]
+
+
+def determine_query_type(query: str) -> QueryType:
+    """
+    Determine whether the query is a TEXT, TICKER, or ADDRESS.
+
+    Args:
+        query: The search query string
+
+    Returns:
+        QueryType enum value
+    """
+    if query.startswith("0x"):
+        return QueryType.ADDRESS
+    if query.startswith("$"):
+        return QueryType.TICKER
+    return QueryType.TEXT
+
+
+def get_liquidity_value(pair: PairModel) -> float:
+    """
+    Extract liquidity USD value from a pair, defaulting to 0.0 if not available.
+
+    Args:
+        pair: PairModel instance
+
+    Returns:
+        Liquidity value in USD as float
+    """
+    return (
+        pair.liquidity.usd if pair.liquidity and pair.liquidity.usd is not None else 0.0
+    )
+
+
+def get_volume_value(
+    pair: PairModel, timeframe: VolumeTimeframe = VolumeTimeframe.TWENTY_FOUR_HOUR
+) -> float:
+    """
+    Extract volume value from a pair for the specified timeframe.
+
+    Args:
+        pair: PairModel instance
+        timeframe: VolumeTimeframe enum value
+
+    Returns:
+        Volume value as float
+    """
+    if not pair.volume:
+        return 0.0
+
+    volume_map = {
+        VolumeTimeframe.FIVE_MINUTES: pair.volume.m5,
+        VolumeTimeframe.ONE_HOUR: pair.volume.h1,
+        VolumeTimeframe.SIX_HOUR: pair.volume.h6,
+        VolumeTimeframe.TWENTY_FOUR_HOUR: pair.volume.h24,
+    }
+
+    return volume_map.get(timeframe, 0.0) or 0.0
+
+
+def get_sort_function(
+    sort_by: SortBy,
+    volume_timeframe: VolumeTimeframe = VolumeTimeframe.TWENTY_FOUR_HOUR,
+) -> Callable[[PairModel], float]:
+    """
+    Get the appropriate sorting function based on sort criteria.
+
+    Args:
+        sort_by: SortBy enum value
+        volume_timeframe: VolumeTimeframe enum value (used when sorting by volume)
+
+    Returns:
+        Callable function that takes a PairModel and returns a float for sorting
+    """
+    if sort_by == SortBy.LIQUIDITY:
+        return get_liquidity_value
+    elif sort_by == SortBy.VOLUME:
+        return lambda pair: get_volume_value(pair, volume_timeframe)
+    else:
+        logger.warning(f"Invalid sort_by value '{sort_by}', defaulting to liquidity.")
+        return get_liquidity_value
+
+
+def sort_pairs_by_criteria(
+    pairs: List[PairModel],
+    sort_by: SortBy = SortBy.LIQUIDITY,
+    volume_timeframe: VolumeTimeframe = VolumeTimeframe.TWENTY_FOUR_HOUR,
+    reverse: bool = True,
+) -> List[PairModel]:
+    """
+    Sort pairs by the specified criteria.
+
+    Args:
+        pairs: List of PairModel instances to sort
+        sort_by: Sorting criteria (liquidity or volume)
+        volume_timeframe: Timeframe for volume sorting
+        reverse: Sort in descending order if True
+
+    Returns:
+        Sorted list of PairModel instances
+    """
+    try:
+        sort_func = get_sort_function(sort_by, volume_timeframe)
+        return sorted(pairs, key=sort_func, reverse=reverse)
+    except Exception as e:
+        logger.error(f"Failed to sort pairs: {e}", exc_info=True)
+        return pairs  # Return original list if sorting fails
+
+
+def filter_ticker_pairs(pairs: List[PairModel], target_ticker: str) -> List[PairModel]:
+    """
+    Filter pairs to only include those where base token symbol matches target ticker.
+
+    Args:
+        pairs: List of PairModel instances
+        target_ticker: Target ticker symbol (case-insensitive)
+
+    Returns:
+        Filtered list of PairModel instances
+    """
+    target_ticker_upper = target_ticker.upper()
+    return [
+        p
+        for p in pairs
+        if p.baseToken
+        and p.baseToken.symbol
+        and p.baseToken.symbol.upper() == target_ticker_upper
+    ]
+
+
+def filter_address_pairs(
+    pairs: List[PairModel], target_address: str
+) -> List[PairModel]:
+    """
+    Filter pairs to only include those matching the target address.
+    Checks pairAddress, baseToken.address, and quoteToken.address.
+
+    Args:
+        pairs: List of PairModel instances
+        target_address: Target address (case-insensitive)
+
+    Returns:
+        Filtered list of PairModel instances
+    """
+    target_address_lower = target_address.lower()
+    return [
+        p
+        for p in pairs
+        if (p.pairAddress and p.pairAddress.lower() == target_address_lower)
+        or (
+            p.baseToken
+            and p.baseToken.address
+            and p.baseToken.address.lower() == target_address_lower
+        )
+        or (
+            p.quoteToken
+            and p.quoteToken.address
+            and p.quoteToken.address.lower() == target_address_lower
+        )
+    ]
+
+
+def create_error_response(
+    error_type: str,
+    message: str,
+    details: Optional[str] = None,
+    additional_data: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    Create a standardized error response in JSON format.
+
+    Args:
+        error_type: Type/category of error
+        message: Human-readable error message
+        details: Optional additional details about the error
+        additional_data: Optional dictionary of additional data to include
+
+    Returns:
+        JSON string containing error information
+    """
+    response = {
+        "error": message,
+        "error_type": error_type,
+    }
+
+    if details:
+        response["details"] = details
+
+    if additional_data:
+        response.update(additional_data)
+
+    return json.dumps(response, indent=2)
+
+
+def create_no_results_response(
+    query_info: str,
+    reason: str = "no results found",
+    additional_data: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    Create a standardized "no results found" response.
+
+    Args:
+        query_info: Information about the query that was performed
+        reason: Reason why no results were found
+        additional_data: Optional additional data to include
+
+    Returns:
+        JSON string containing no results information
+    """
+    response = {
+        "message": f"No results found for the query. Reason: {reason}.",
+        "query_info": query_info,
+        "pairs": [],
+    }
+
+    if additional_data:
+        response.update(additional_data)
+
+    return json.dumps(response, indent=2)
+
+
+def handle_validation_error(
+    error: ValidationError, query_info: str, data_length: Optional[int] = None
+) -> str:
+    """
+    Handle validation errors in a standardized way.
+
+    Args:
+        error: The ValidationError that occurred
+        query_info: Information about the query being processed
+        data_length: Optional length of the data that failed validation
+
+    Returns:
+        JSON error response string
+    """
+    log_message = f"Failed to validate DexScreener response structure for {query_info}. Error: {error}"
+    if data_length:
+        log_message += f". Raw data length: {data_length}"
+
+    logger.error(log_message, exc_info=True)
+
+    return create_error_response(
+        error_type="validation_error",
+        message="Failed to parse successful DexScreener API response",
+        details=str(error.errors()),
+        additional_data={"query_info": query_info},
+    )
+
+
+def truncate_large_fields(
+    data: Dict[str, Any], max_length: int = 500
+) -> Dict[str, Any]:
+    """
+    Truncate large string fields in error response data to avoid overwhelming the LLM.
+
+    Args:
+        data: Dictionary potentially containing large string fields
+        max_length: Maximum length for string fields before truncation
+
+    Returns:
+        Dictionary with truncated fields
+    """
+    truncated = data.copy()
+
+    for key in ["details", "response_body"]:
+        if isinstance(truncated.get(key), str) and len(truncated[key]) > max_length:
+            truncated[key] = truncated[key][:max_length] + "... (truncated)"
+
+    return truncated
+
+
+def group_pairs_by_token(pairs: List[PairModel]) -> Dict[str, List[PairModel]]:
+    """
+    Group pairs by token address for better organization in multi-token responses.
+
+    Args:
+        pairs: List of PairModel instances
+
+    Returns:
+        Dictionary mapping lowercase token addresses to lists of pairs
+    """
+    tokens_data = {}
+
+    for pair in pairs:
+        # Group by base token address
+        if pair.baseToken and pair.baseToken.address:
+            base_addr = pair.baseToken.address.lower()
+            if base_addr not in tokens_data:
+                tokens_data[base_addr] = []
+            tokens_data[base_addr].append(pair)
+
+        # Group by quote token address
+        if pair.quoteToken and pair.quoteToken.address:
+            quote_addr = pair.quoteToken.address.lower()
+            if quote_addr not in tokens_data:
+                tokens_data[quote_addr] = []
+            tokens_data[quote_addr].append(pair)
+
+    return tokens_data
+
+
+def validate_chain_id(chain_id: str) -> bool:
+    """
+    Validate if the chain ID is supported.
+
+    Args:
+        chain_id: Chain ID to validate
+
+    Returns:
+        True if chain ID is supported, False otherwise
+    """
+    return chain_id.lower() in SUPPORTED_CHAINS
+
+
+def format_success_response(data: Dict[str, Any]) -> str:
+    """
+    Format a successful response as JSON string.
+
+    Args:
+        data: Response data dictionary
+
+    Returns:
+        JSON formatted string
+    """
+    return json.dumps(data, indent=2)


### PR DESCRIPTION
## Description

**3 new skills added in Dexscreener**

1. get_pair_info - Get comprehensive data for a specific trading pair
  Example: "Get detailed info for pair address 0xa43fe16908251ee70ef74718545e4fe6c5ccec9f on Ethereum"

2. get_token_pairs - Find all trading pairs/pools for a specific token
  Example: "Find all trading pairs for token 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984 on Ethereum"

3.  get_tokens_info - Analyze up to 30 tokens at once (perfect for portfolio analysis)
  Example: "Get trading data for these tokens on Ethereum: 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984,
  0xa0b86a33e6180d93e26c8fffab74649b6b0d3c29"


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Improvement
- [ ] Documentation Update

## Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
