### PR TITLE
feat: add reasoning_effort parameter for gpt-5 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.6.22
+
+### Features
+- **XMTP Skills Enhancement**: Expanded XMTP skills to support multiple networks, improving cross-chain communication capabilities
+- **DexScreener Integration**: Added comprehensive DexScreener skills for enhanced token and pair information retrieval
+  - New `get_pair_info` skill for detailed trading pair data
+  - New `get_token_pairs` skill for token pair discovery
+  - New `get_tokens_info` skill for comprehensive token information
+  - Enhanced search functionality with improved utilities
+
+### Technical Improvements
+- Added new Web3 client utilities for better blockchain interaction
+- Enhanced chat functionality in core system
+- Updated agent schema with improved configuration options
+- Improved skill base classes with better error handling
+
+### Dependencies
+- Updated project dependencies for better compatibility and security
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.21...v0.6.22
+
 ## v0.6.21
 
 ### Features

--- a/intentkit/models/llm.py
+++ b/intentkit/models/llm.py
@@ -612,6 +612,9 @@ class OpenAILLM(LLMModel):
         if info.api_base:
             kwargs["openai_api_base"] = info.api_base
 
+        if self.model_name.startswith("gpt-5"):
+            kwargs["reasoning_effort"] = "minimal"
+
         logger.debug(f"Creating ChatOpenAI instance with kwargs: {kwargs}")
 
         return ChatOpenAI(**kwargs)


### PR DESCRIPTION
This PR adds support for the `reasoning_effort` parameter when using GPT-5 models in the OpenAI LLM configuration.

## Changes
- Added automatic setting of `reasoning_effort: "minimal"` for models starting with "gpt-5"
- This ensures proper configuration for GPT-5 reasoning models

## Testing
- Code follows existing patterns in the OpenAI LLM class
- Linting passes with ruff format and check