### PR TITLE
refactor: move asyncio import to top of file and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v0.6.25
+
+### Refactoring
+- Simplified Dockerfile dependency installation process
+- Removed unnecessary await from sync get_system_config calls in Twitter module
+
+### Build & Configuration
+- Updated project name and added workspace configuration
+
+### Documentation
+- Updated changelog for v0.6.23 release
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.23...v0.6.25
+
 ## v0.6.23
 
 ### Features

--- a/app/admin/account_checking.py
+++ b/app/admin/account_checking.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -693,7 +694,5 @@ async def main():
 
 
 if __name__ == "__main__":
-    import asyncio
-
     # Run the main function
     asyncio.run(main())


### PR DESCRIPTION
This PR includes:

- **Code Style Improvement**: Moved asyncio import to the top of the file in `app/admin/account_checking.py` following Python import conventions
- **Documentation**: Updated changelog for v0.6.25 release

The import refactoring improves code organization by placing all imports at the beginning of the file as per PEP 8 guidelines.