### PR TITLE
fix: update pypi publish workflow and changelog for v0.6.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
         
     - name: Publish to PyPI
       run: |
-        cd intentkit
-        uv publish --token ${{ secrets.UV_PUBLISH_TOKEN }}
+        uv publish --token ${{ secrets.UV_PUBLISH_TOKEN }} dist/*
 
   docker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.6.26
+
+### Refactoring
+- Move asyncio import to top of file in account_checking.py
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.25...v0.6.26
+
 ## v0.6.25
 
 ### Refactoring


### PR DESCRIPTION
This PR includes:

- Fix PyPI publish workflow to use correct dist path
- Update changelog for v0.6.26 release

### Changes
- Modified `.github/workflows/build.yml` to fix the PyPI publish step
- Updated `CHANGELOG.md` with v0.6.26 release notes

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update