### PR TITLE
fix: add missing amount fields to CreditTransactionTable instantiations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.7.0
+
+### Features
+- **Config Enhancement**: Add intentkit_prompt to config and prompt system for better customization
+- **Credit Management**: Add comprehensive credit event consistency checker with base validation
+- **Migration Tools**: Add script to migrate credit accounts from transactions
+- **Optimization**: Optimize credit event consistency checking scripts for better performance
+
+### Fixes
+- **Model Update**: Change default model to gpt-5-mini for improved performance
+- **Credit Events**: Update and improve credit event consistency check script
+- **Workflow**: Update pypi publish workflow and changelog
+
+### Refactoring
+- **Credit Event Logic**: Improve readability of credit type distribution logic
+- **Performance**: Remove redundant logs and add batch stats tracking for better monitoring
+
+### Chores
+- **Documentation**: Update LLM rules and guidelines
+- **Migration Scripts**: Fix and improve migration scripts
+
+**Full Changelog**: https://github.com/crestalnetwork/intentkit/compare/v0.6.26...v0.7.0
+
 ## v0.6.26
 
 ### Refactoring

--- a/intentkit/core/credit.py
+++ b/intentkit/core/credit.py
@@ -1628,6 +1628,9 @@ async def refill_free_credits_for_account(
         credit_debit=CreditDebit.CREDIT,
         change_amount=amount_to_add,
         credit_type=CreditType.FREE,
+        free_amount=amount_to_add,
+        reward_amount=Decimal("0"),
+        permanent_amount=Decimal("0"),
     )
     session.add(user_tx)
 
@@ -1640,6 +1643,9 @@ async def refill_free_credits_for_account(
         credit_debit=CreditDebit.DEBIT,
         change_amount=amount_to_add,
         credit_type=CreditType.FREE,
+        free_amount=amount_to_add,
+        reward_amount=Decimal("0"),
+        permanent_amount=Decimal("0"),
     )
     session.add(platform_tx)
 


### PR DESCRIPTION
## Summary

Fixed missing amount fields in CreditTransactionTable instantiations within the `refill_free_credits_for_account` function.

## Changes

- Added `free_amount`, `reward_amount`, and `permanent_amount` field assignments to both user and platform transaction records in the refill function
- Ensures data consistency by properly setting all four amount fields (`change_amount`, `free_amount`, `reward_amount`, `permanent_amount`) for every CreditTransactionTable instantiation

## Details

The refill function was missing explicit assignments for the three amount breakdown fields, which could lead to incomplete transaction records. This fix ensures:

- `free_amount` is set to `amount_to_add` for free credit transactions
- `reward_amount` and `permanent_amount` are explicitly set to `Decimal("0")` when not applicable
- All CreditTransactionTable instantiations now have complete field assignments

## Files Changed

- `intentkit/core/credit.py`: Updated `refill_free_credits_for_account` function