### PR TITLE
feat: add platform API key support for firecrawl skill

### DIFF
--- a/intentkit/skills/firecrawl/base.py
+++ b/intentkit/skills/firecrawl/base.py
@@ -29,9 +29,7 @@ class FirecrawlBaseTool(IntentKitSkill):
             else:
                 raise ToolException("No api_key found in agent_owner configuration")
         else:
-            raise ToolException(
-                f"Invalid API key provider: {api_key_provider}. Only 'agent_owner' is supported for Firecrawl."
-            )
+            return self.skill_store.get_system_config("firecrawl_api_key")
 
     @property
     def category(self) -> str:

--- a/intentkit/skills/firecrawl/schema.json
+++ b/intentkit/skills/firecrawl/schema.json
@@ -93,12 +93,14 @@
       "title": "API Key Provider",
       "description": "Provider of the API key",
       "enum": [
+        "platform",
         "agent_owner"
       ],
       "x-enum-title": [
+        "Nation Hosted",
         "Owner Provided"
       ],
-      "default": "agent_owner"
+      "default": "platform"
     },
     "api_key": {
       "type": "string",


### PR DESCRIPTION
This PR adds support for platform-provided API keys in the Firecrawl skill, allowing users to choose between platform-hosted and owner-provided API key configurations.

## Changes
- Updated `base.py` to handle platform API key provider by fetching from system config
- Modified `schema.json` to include "platform" as an API key provider option with "Nation Hosted" as the display name
- Changed default API key provider from "agent_owner" to "platform"

## Benefits
- Provides flexibility for users to choose their preferred API key configuration
- Enables platform-hosted API key management for better user experience
- Maintains backward compatibility with existing owner-provided configurations