### PR TITLE
feat: add required field validation for agent name in json schema

### DIFF
--- a/intentkit/models/agent.py
+++ b/intentkit/models/agent.py
@@ -647,6 +647,9 @@ class AgentUserInput(AgentCore):
     model_config = ConfigDict(
         title="AgentUserInput",
         from_attributes=True,
+        json_schema_extra={
+            "required": ["name"],
+        },
     )
 
     short_term_memory_strategy: Annotated[


### PR DESCRIPTION
This PR adds JSON schema validation to ensure that the `name` field is required when creating or updating agents through the API.

## Changes
- Added `json_schema_extra` configuration to `AgentUserInput` model
- Specified `name` as a required field in the JSON schema

## Benefits
- Improves API validation by making agent name mandatory
- Provides clearer error messages when name field is missing
- Enhances data integrity for agent creation/updates

## Testing
- Linting and formatting checks passed
- No breaking changes to existing functionality