### PR TITLE
fix: rename deploy_agent to override_agent and fix annotation syntax

### DIFF
--- a/intentkit/models/agent.py
+++ b/intentkit/models/agent.py
@@ -1518,16 +1518,16 @@ class AgentResponse(Agent):
     )
 
     # Override privacy fields to exclude them from JSON schema
-    purpose: Annotated[Optional[str], SkipJsonSchema] = None
-    personality: Annotated[Optional[str], SkipJsonSchema] = None
-    principles: Annotated[Optional[str], SkipJsonSchema] = None
-    prompt: Annotated[Optional[str], SkipJsonSchema] = None
-    prompt_append: Annotated[Optional[str], SkipJsonSchema] = None
-    temperature: Annotated[Optional[float], SkipJsonSchema] = None
-    frequency_penalty: Annotated[Optional[float], SkipJsonSchema] = None
-    telegram_entrypoint_prompt: Annotated[Optional[str], SkipJsonSchema] = None
-    telegram_config: Annotated[Optional[dict], SkipJsonSchema] = None
-    xmtp_entrypoint_prompt: Annotated[Optional[str], SkipJsonSchema] = None
+    purpose: SkipJsonSchema[Optional[str]] = None
+    personality: SkipJsonSchema[Optional[str]] = None
+    principles: SkipJsonSchema[Optional[str]] = None
+    prompt: SkipJsonSchema[Optional[str]] = None
+    prompt_append: SkipJsonSchema[Optional[str]] = None
+    temperature: SkipJsonSchema[Optional[float]] = None
+    frequency_penalty: SkipJsonSchema[Optional[float]] = None
+    telegram_entrypoint_prompt: SkipJsonSchema[Optional[str]] = None
+    telegram_config: SkipJsonSchema[Optional[dict]] = None
+    xmtp_entrypoint_prompt: SkipJsonSchema[Optional[str]] = None
 
     # Additional fields specific to AgentResponse
     cdp_wallet_address: Annotated[


### PR DESCRIPTION
This PR includes two important fixes:

1. **Function rename**: Changed `deploy_agent` to `override_agent` in the admin API to better reflect the function's purpose
2. **Annotation syntax fix**: Updated `SkipJsonSchema` annotations in the `AgentResponse` model from `Annotated[Type, SkipJsonSchema]` to `SkipJsonSchema[Type]` for proper Pydantic v2 compatibility

## Changes
- `app/admin/api.py`: Updated function call from `deploy_agent` to `override_agent`
- `intentkit/models/agent.py`: Fixed annotation syntax for privacy fields in `AgentResponse` class

These changes improve code clarity and ensure proper type annotation handling.