### PR TITLE
fix: centralize llm and skill listings

### DIFF
--- a/app/admin/generator/validation.py
+++ b/app/admin/generator/validation.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List
 import jsonschema
 from pydantic import BaseModel, Field, ValidationError
 
-from intentkit.config.config import config
 from intentkit.models.agent import Agent, AgentUpdate
 
 logger = logging.getLogger(__name__)
@@ -63,11 +62,8 @@ async def validate_schema(data: Dict[str, Any]) -> ValidationResult:
     Returns:
         ValidationResult with validation status and errors
     """
-    # Use the shared schema function with admin configuration
-    schema = await Agent.get_json_schema(
-        filter_owner_api_skills=True,
-        admin_llm_skill_control=config.admin_llm_skill_control,
-    )
+    # Use the shared schema function
+    schema = await Agent.get_json_schema(filter_owner_api_skills=True)
     return await validate_schema_against_json_schema(data, schema)
 
 

--- a/app/admin/schema.py
+++ b/app/admin/schema.py
@@ -7,7 +7,6 @@ from fastapi import Path as PathParam
 from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from intentkit.config.config import config
 from intentkit.models.agent import Agent
 from intentkit.models.db import get_db
 from intentkit.utils.error import IntentKitAPIError
@@ -37,9 +36,7 @@ async def get_agent_schema(db: AsyncSession = Depends(get_db)) -> JSONResponse:
     * `JSONResponse` - The complete JSON schema for the Agent model with application/json content type
     """
     return JSONResponse(
-        content=await Agent.get_json_schema(
-            db, admin_llm_skill_control=config.admin_llm_skill_control
-        ),
+        content=await Agent.get_json_schema(db),
         media_type="application/json",
     )
 

--- a/intentkit/config/config.py
+++ b/intentkit/config/config.py
@@ -78,9 +78,6 @@ class Config:
         self.debug_auth_enabled = self.load("DEBUG_AUTH_ENABLED", "false") == "true"
         self.debug_username = self.load("DEBUG_USERNAME")
         self.debug_password = self.load("DEBUG_PASSWORD")
-        self.admin_llm_skill_control = (
-            self.load("ADMIN_LLM_SKILL_CONTROL", "false") == "true"
-        )
         # Payment
         self.payment_enabled = self.load("PAYMENT_ENABLED", "false") == "true"
         # Open API for agent

--- a/intentkit/core/engine.py
+++ b/intentkit/core/engine.py
@@ -368,10 +368,7 @@ async def stream_agent(message: ChatMessageCreate):
         ]
 
     # Process input message to handle @skill patterns
-    if config.admin_llm_skill_control:
-        input_message = await explain_prompt(input.message)
-    else:
-        input_message = input.message
+    input_message = await explain_prompt(input.message)
 
     # super mode
     recursion_limit = 30


### PR DESCRIPTION
## Summary
- add `get_all` helpers on LLMModelInfo and Skill that merge CSV defaults with database overrides
- update metadata endpoints to rely on the new helpers instead of recomputing listings
- reuse the shared lists when building the agent JSON schema so filtering logic operates on a single source of truth

## Testing
- uv run ruff format
- uv run ruff check --fix
- uv run pytest *(fails: ModuleNotFoundError: No module named 'intentkit.abstracts')*

------
https://chatgpt.com/codex/tasks/task_b_68cd98869740832f985e6ff6aa9bc09f