### PR TITLE
fix: add replace_existing=True to scheduler jobs to prevent duplicate job errors

### DIFF
--- a/app/admin/scheduler.py
+++ b/app/admin/scheduler.py
@@ -54,6 +54,7 @@ def create_scheduler():
         trigger=CronTrigger(hour=0, minute=0, timezone="UTC"),
         id="reset_daily_quotas",
         name="Reset daily quotas",
+        replace_existing=True,
     )
 
     # Reset monthly quotas at UTC 00:00 on the first day of each month
@@ -62,6 +63,7 @@ def create_scheduler():
         trigger=CronTrigger(day=1, hour=0, minute=0, timezone="UTC"),
         id="reset_monthly_quotas",
         name="Reset monthly quotas",
+        replace_existing=True,
     )
 
     # Check for expiring tokens every 5 minutes
@@ -70,6 +72,7 @@ def create_scheduler():
         trigger=CronTrigger(minute="*/5", timezone="UTC"),  # Run every 5 minutes
         id="refresh_twitter_tokens",
         name="Refresh expiring Twitter tokens",
+        replace_existing=True,
     )
 
     # Refill free credits every 10 minutes
@@ -78,6 +81,7 @@ def create_scheduler():
         trigger=CronTrigger(minute="20", timezone="UTC"),  # Run every hour
         id="refill_free_credits",
         name="Refill free credits",
+        replace_existing=True,
     )
 
     # Update agent action costs hourly
@@ -86,6 +90,7 @@ def create_scheduler():
         trigger=CronTrigger(minute=40, timezone="UTC"),
         id="update_agent_action_cost",
         name="Update agent action costs",
+        replace_existing=True,
     )
 
     # Send heartbeat every minute
@@ -95,6 +100,7 @@ def create_scheduler():
             trigger=CronTrigger(minute="*", timezone="UTC"),  # Run every minute
             id="scheduler_heartbeat",
             name="Scheduler Heartbeat",
+            replace_existing=True,
         )
 
     return scheduler


### PR DESCRIPTION
## Summary

This PR fixes potential duplicate job errors in the admin scheduler by adding `replace_existing=True` parameter to all scheduled jobs.

## Changes

- Added `replace_existing=True` to all scheduler job configurations in `app/admin/scheduler.py`:
  - Reset daily quotas job
  - Reset monthly quotas job  
  - Refresh Twitter tokens job
  - Refill free credits job
  - Update agent action costs job
  - Scheduler heartbeat job

## Why this change is needed

Without `replace_existing=True`, the APScheduler may throw errors when trying to add jobs with the same ID that already exist, especially during application restarts or when the scheduler is reinitialized. This parameter ensures that existing jobs are replaced rather than causing conflicts.

## Testing

- Linting and formatting checks passed
- No breaking changes to existing functionality