### PR TITLE
Add initial utility tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/utils/test_chain.py
+++ b/tests/utils/test_chain.py
@@ -1,0 +1,71 @@
+import pytest
+
+from intentkit.utils.chain import (
+    Chain,
+    ChainConfig,
+    ChainProvider,
+    Network,
+    NetworkId,
+)
+
+
+class DummyChainProvider(ChainProvider):
+    def __init__(self):
+        super().__init__()
+        self.chain_configs = {
+            Network.BaseMainnet: ChainConfig(
+                chain=Chain.Base,
+                network=Network.BaseMainnet,
+                rpc_url="https://example-rpc",
+                ens_url="https://example-ens",
+                wss_url="wss://example",
+            )
+        }
+
+    def init_chain_configs(self, api_key: str):
+        return self.chain_configs
+
+
+def test_chain_config_properties():
+    config = ChainConfig(
+        chain=Chain.Ethereum,
+        network=Network.EthereumMainnet,
+        rpc_url="https://eth",
+        ens_url="https://ens",
+        wss_url="wss://eth",
+    )
+
+    assert config.chain is Chain.Ethereum
+    assert config.network is Network.EthereumMainnet
+    assert config.network_id == NetworkId.EthereumMainnet
+    assert config.rpc_url == "https://eth"
+    assert config.ens_url == "https://ens"
+    assert config.wss_url == "wss://eth"
+
+
+def test_chain_provider_fetch_by_network_and_id():
+    provider = DummyChainProvider()
+
+    config = provider.get_chain_config(Network.BaseMainnet)
+    assert config.rpc_url == "https://example-rpc"
+
+    config_by_id = provider.get_chain_config_by_id(NetworkId.BaseMainnet)
+    assert config_by_id is config
+
+
+def test_chain_provider_missing_network():
+    provider = DummyChainProvider()
+
+    with pytest.raises(Exception) as exc:
+        provider.get_chain_config(Network.EthereumSepolia)
+
+    assert "chain config for network" in str(exc.value)
+
+
+def test_chain_provider_missing_network_id():
+    provider = DummyChainProvider()
+
+    with pytest.raises(Exception) as exc:
+        provider.get_chain_config_by_id(NetworkId.GnosisMainnet)
+
+    assert "chain config for network" in str(exc.value)

--- a/tests/utils/test_error.py
+++ b/tests/utils/test_error.py
@@ -1,0 +1,39 @@
+from intentkit.utils.error import format_validation_errors
+
+
+def test_format_validation_errors_with_field_path_and_type():
+    errors = [
+        {
+            "loc": ("body", "user", "email"),
+            "msg": "value is not a valid email address",
+            "type": "value_error.email",
+        },
+        {
+            "loc": ("body", "items", 0, "price"),
+            "msg": "value is not a valid decimal",
+            "type": "type_error.decimal",
+        },
+    ]
+
+    result = format_validation_errors(errors)
+
+    assert (
+        "Field 'user -> email' (value_error.email): value is not a valid email address"
+        in result
+    )
+    assert (
+        "Field 'items -> 0 -> price' (type_error.decimal): value is not a valid decimal"
+        in result
+    )
+
+
+def test_format_validation_errors_without_field_path():
+    errors = [
+        {
+            "loc": (),
+            "msg": "root error",
+            "type": "value_error",
+        }
+    ]
+
+    assert format_validation_errors(errors) == "root error"

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,37 @@
+import json
+import logging
+
+from intentkit.utils.logging import JsonFormatter
+
+
+def create_log_record(message: str) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="intentkit.tests",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    record.__dict__["extra"] = {"component": "tests"}
+    return record
+
+
+def test_json_formatter_includes_extra_fields():
+    formatter = JsonFormatter()
+    record = create_log_record("hello world")
+
+    output = formatter.format(record)
+    payload = json.loads(output)
+
+    assert payload["message"] == "hello world"
+    assert payload["component"] == "tests"
+    assert payload["name"] == "intentkit.tests"
+
+
+def test_json_formatter_respects_filter_function():
+    formatter = JsonFormatter(lambda record: False)
+    record = create_log_record("filtered")
+
+    assert formatter.format(record) == ""

--- a/tests/utils/test_random.py
+++ b/tests/utils/test_random.py
@@ -1,0 +1,30 @@
+import string
+
+from intentkit.utils.random import generate_tx_confirm_string
+
+
+def test_generate_tx_confirm_string_prefix_and_length():
+    token = generate_tx_confirm_string(8)
+
+    assert token.startswith("tx-")
+    assert len(token) == len("tx-") + 8
+    assert all(char in string.ascii_letters + string.digits for char in token[3:])
+
+
+def test_generate_tx_confirm_string_uniqueness(monkeypatch):
+    class DummyRandom:
+        def __init__(self):
+            self.calls = -1
+            self.values = list(string.ascii_letters + string.digits)
+
+        def choice(self, seq):
+            self.calls += 1
+            return seq[self.calls % len(seq)]
+
+    dummy = DummyRandom()
+    monkeypatch.setattr("intentkit.utils.random.random", dummy)
+
+    token = generate_tx_confirm_string(4)
+
+    expected = "tx-" + "".join(dummy.values[i] for i in range(4))
+    assert token == expected


### PR DESCRIPTION
## Summary
- add a pytest configuration that puts the repository root on the import path for tests
- create initial tests for chain, error formatting, logging, and random utility helpers

## Testing
- `uv run pytest tests`


------
https://chatgpt.com/codex/tasks/task_b_68d02880c474832fb13e5a49db70b44e