### PR TITLE
improve: annotate lifi functions

### DIFF
--- a/intentkit/skills/lifi/__init__.py
+++ b/intentkit/skills/lifi/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, TypedDict
+from typing import Any, List, Optional, TypedDict
 
 from intentkit.abstracts.skill import SkillStoreABC
 from intentkit.skills.base import SkillConfig, SkillState
@@ -32,10 +32,10 @@ async def get_skills(
     config: "Config",
     is_private: bool,
     store: SkillStoreABC,
-    **_,
+    **_: Any,
 ) -> list[LiFiBaseTool]:
     """Get all LiFi skills."""
-    available_skills = []
+    available_skills: list[str] = []
 
     # Log configuration
     logger.info(f"[LiFi_Skills] Initializing with config: {config}")
@@ -57,7 +57,7 @@ async def get_skills(
     logger.info(f"[LiFi_Skills] Available skills: {available_skills}")
 
     # Get each skill using the cached getter
-    skills = []
+    skills: list[LiFiBaseTool] = []
     for name in available_skills:
         try:
             skill = get_lifi_skill(name, store, config)

--- a/intentkit/skills/lifi/token_quote.py
+++ b/intentkit/skills/lifi/token_quote.py
@@ -65,7 +65,7 @@ class TokenQuote(LiFiBaseTool):
         skill_store: SkillStoreABC,
         default_slippage: float = 0.03,
         allowed_chains: Optional[List[str]] = None,
-    ):
+    ) -> None:
         """Initialize the TokenQuote skill with configuration options."""
         super().__init__(skill_store=skill_store)
         self.default_slippage = default_slippage
@@ -78,7 +78,7 @@ class TokenQuote(LiFiBaseTool):
         from_token: str,
         to_token: str,
         from_amount: str,
-        slippage: float = None,
+        slippage: Optional[float] = None,
         **kwargs,
     ) -> str:
         """Get a quote for token transfer."""


### PR DESCRIPTION
## Summary
- annotate LiFi skill registration helpers with explicit argument and return types
- add detailed wallet provider and quote typing across the TokenExecute flow
- tighten TokenQuote and shared utilities with optional parameter and response typing

## Testing
- uv run ruff format intentkit/skills/lifi/__init__.py intentkit/skills/lifi/utils.py intentkit/skills/lifi/token_execute.py intentkit/skills/lifi/token_quote.py
- uv run ruff check --fix intentkit/skills/lifi/__init__.py intentkit/skills/lifi/utils.py intentkit/skills/lifi/token_execute.py intentkit/skills/lifi/token_quote.py
- uv run ruff check intentkit/skills/lifi/__init__.py intentkit/skills/lifi/utils.py intentkit/skills/lifi/token_execute.py intentkit/skills/lifi/token_quote.py

------
https://chatgpt.com/codex/tasks/task_b_68d1334350e4832fadd0e39e9782cc70