### PR TITLE
Fix Enso wallet integration to rely on wallet provider

### DIFF
--- a/intentkit/skills/enso/__init__.py
+++ b/intentkit/skills/enso/__init__.py
@@ -36,7 +36,7 @@ class Config(SkillConfig):
 
     states: SkillStates
     api_token: NotRequired[str]
-    main_tokens: List[str]
+    main_tokens: NotRequired[List[str]]
 
 
 async def get_skills(

--- a/intentkit/skills/enso/networks.py
+++ b/intentkit/skills/enso/networks.py
@@ -7,8 +7,6 @@ from pydantic import BaseModel, Field
 
 from .base import EnsoBaseTool, base_url
 
-logger = logging.getLogger(__name__)
-
 
 class EnsoGetNetworksInput(BaseModel):
     """
@@ -36,6 +34,9 @@ class EnsoGetNetworksOutput(BaseModel):
     res: list[ConnectedNetwork] | None = Field(
         None, description="Response containing networks and metadata"
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 class EnsoGetNetworks(EnsoBaseTool):

--- a/intentkit/skills/enso/wallet.py
+++ b/intentkit/skills/enso/wallet.py
@@ -4,23 +4,13 @@ import httpx
 from langchain.tools.base import ToolException
 from pydantic import BaseModel, Field
 
-from .base import EnsoBaseTool, base_url, default_chain_id
+from .base import EnsoBaseTool, base_url
 
 
 class EnsoGetBalancesInput(BaseModel):
-    """
-    Input model for retrieving wallet balances.
-    """
+    """Input model for retrieving wallet balances."""
 
-    chainId: int = Field(
-        default_chain_id, description="Chain ID of the blockchain network"
-    )
-    # eoaAddress: str = Field(
-    #     description="Address of the eoa with which to associate the ensoWallet for balances"
-    # )
-    # useEoa: bool = Field(
-    #     description="If true returns balances for the provided eoaAddress, instead of the associated ensoWallet"
-    # )
+    chainId: int | None = Field(None, description="Chain ID of the blockchain network")
 
 
 class WalletBalance(BaseModel):
@@ -31,9 +21,7 @@ class WalletBalance(BaseModel):
 
 
 class EnsoGetBalancesOutput(BaseModel):
-    """
-    Output model for retrieving wallet balances.
-    """
+    """Output model for retrieving wallet balances."""
 
     res: list[WalletBalance] | None = Field(
         None, description="The wallet's balances along with token details."
@@ -41,15 +29,7 @@ class EnsoGetBalancesOutput(BaseModel):
 
 
 class EnsoGetWalletBalances(EnsoBaseTool):
-    """
-    This tool allows querying for first 20 token balances of a specific wallet
-    and blockchain network.
-
-    Attributes:
-        name (str): Name of the tool, specifically "enso_get_wallet_balances".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
-    """
+    """Retrieve token balances of a wallet on a specified blockchain network."""
 
     name: str = "enso_get_wallet_balances"
     description: str = (
@@ -59,61 +39,48 @@ class EnsoGetWalletBalances(EnsoBaseTool):
 
     async def _arun(
         self,
-        chainId: int = default_chain_id,
-        **kwargs,
+        chainId: int | None = None,
+        **_: object,
     ) -> EnsoGetBalancesOutput:
-        """
-        Run the tool to get token balances of a wallet.
-
-        Args:
-            chainId (int): Chain ID of the blockchain network.
-
-        Returns:
-            EnsoGetBalancesOutput: The list of balances or an error message.
-        """
-        url = f"{base_url}/api/v1/wallet/balances"
-
         context = self.get_context()
+        resolved_chain_id = self.resolve_chain_id(context, chainId)
         api_token = self.get_api_token(context)
-        account = await self.get_account(context)
+        wallet_address = await self.get_wallet_address(context)
+
         headers = {
             "accept": "application/json",
             "Authorization": f"Bearer {api_token}",
         }
 
-        params = EnsoGetBalancesInput(chainId=chainId).model_dump(exclude_none=True)
-        params["eoaAddress"] = account.address
+        params = EnsoGetBalancesInput(chainId=resolved_chain_id).model_dump(
+            exclude_none=True
+        )
+        params["eoaAddress"] = wallet_address
         params["useEoa"] = True
 
         async with httpx.AsyncClient() as client:
             try:
-                # Send the GET request
-                response = await client.get(url, headers=headers, params=params)
+                response = await client.get(
+                    f"{base_url}/api/v1/wallet/balances",
+                    headers=headers,
+                    params=params,
+                )
                 response.raise_for_status()
-
-                # Map the response JSON into the WalletBalance model
                 json_dict = response.json()[:20]
                 res = [WalletBalance(**item) for item in json_dict]
-
-                # Return the parsed response
                 return EnsoGetBalancesOutput(res=res)
             except httpx.RequestError as req_err:
                 raise ToolException("request error from Enso API") from req_err
             except httpx.HTTPStatusError as http_err:
                 raise ToolException("http error from Enso API") from http_err
-            except Exception as e:
-                raise ToolException(f"error from Enso API: {e}") from e
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ToolException(f"error from Enso API: {exc}") from exc
 
 
 class EnsoGetApprovalsInput(BaseModel):
-    """
-    Input model for retrieving wallet approvals.
-    """
+    """Input model for retrieving wallet approvals."""
 
-    chainId: int = Field(
-        default_chain_id, description="Chain ID of the blockchain network"
-    )
-    fromAddress: str = Field(description="Address of the wallet")
+    chainId: int | None = Field(None, description="Chain ID of the blockchain network")
     routingStrategy: Literal["ensowallet", "router", "delegate"] | None = Field(
         None, description="Routing strategy to use"
     )
@@ -126,9 +93,7 @@ class WalletAllowance(BaseModel):
 
 
 class EnsoGetApprovalsOutput(BaseModel):
-    """
-    Output model for retrieving wallet approvals.
-    """
+    """Output model for retrieving wallet approvals."""
 
     res: list[WalletAllowance] | None = Field(
         None, description="Response containing the list of token approvals."
@@ -136,42 +101,24 @@ class EnsoGetApprovalsOutput(BaseModel):
 
 
 class EnsoGetWalletApprovals(EnsoBaseTool):
-    """
-    This tool allows querying for first 50 token spend approvals associated with a specific wallet
-    and blockchain network.
-
-    Attributes:
-        name (str): Name of the tool, specifically "enso_get_wallet_approvals".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
-    """
+    """Retrieve token spend approvals for a wallet on a specified blockchain network."""
 
     name: str = "enso_get_wallet_approvals"
     description: str = (
         "Retrieve token spend approvals for a wallet on a specified blockchain network."
     )
-    args_schema: Type[BaseModel] = EnsoGetApprovalsOutput
+    args_schema: Type[BaseModel] = EnsoGetApprovalsInput
 
     async def _arun(
         self,
-        chainId: int = default_chain_id,
-        **kwargs,
+        chainId: int | None = None,
+        routingStrategy: Literal["ensowallet", "router", "delegate"] | None = None,
+        **_: object,
     ) -> EnsoGetApprovalsOutput:
-        """
-        Run the tool to get token approvals for a wallet.
-
-        Args:
-            chainId (int): Chain ID of the blockchain network.
-            **kwargs: optional kwargs for the tool with args schema defined in EnsoGetApprovalsInput.
-
-        Returns:
-            EnsoGetApprovalsOutput: The list of approvals or an error message.
-        """
-        url = f"{base_url}/api/v1/wallet/approvals"
-
         context = self.get_context()
+        resolved_chain_id = self.resolve_chain_id(context, chainId)
         api_token = self.get_api_token(context)
-        account = await self.get_account(context)
+        wallet_address = await self.get_wallet_address(context)
 
         headers = {
             "accept": "application/json",
@@ -179,26 +126,21 @@ class EnsoGetWalletApprovals(EnsoBaseTool):
         }
 
         params = EnsoGetApprovalsInput(
-            chainId=chainId,
-            fromAddress=account.address,
-        )
-
-        if kwargs.get("routingStrategy"):
-            params.routingStrategy = kwargs["routingStrategy"]
+            chainId=resolved_chain_id,
+            routingStrategy=routingStrategy,
+        ).model_dump(exclude_none=True)
+        params["fromAddress"] = wallet_address
 
         async with httpx.AsyncClient() as client:
             try:
-                # Send the GET request
                 response = await client.get(
-                    url, headers=headers, params=params.model_dump(exclude_none=True)
+                    f"{base_url}/api/v1/wallet/approvals",
+                    headers=headers,
+                    params=params,
                 )
                 response.raise_for_status()
-
-                # Map the response JSON into the ApprovalsResponse model
                 json_dict = response.json()[:50]
                 res = [WalletAllowance(**item) for item in json_dict]
-
-                # Return the parsed response
                 return EnsoGetApprovalsOutput(res=res)
             except httpx.RequestError as req_err:
                 raise ToolException(
@@ -208,29 +150,23 @@ class EnsoGetWalletApprovals(EnsoBaseTool):
                 raise ToolException(
                     f"http error from Enso API: {http_err}"
                 ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Enso API: {e}") from e
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ToolException(f"error from Enso API: {exc}") from exc
 
 
 class EnsoWalletApproveInput(BaseModel):
-    """
-    Input model for approve the wallet.
-    """
+    """Input model for approving token spend for the wallet."""
 
     tokenAddress: str = Field(description="ERC20 token address of the token to approve")
     amount: int = Field(description="Amount of tokens to approve in wei")
-    chainId: int = Field(
-        default_chain_id, description="Chain ID of the blockchain network"
-    )
+    chainId: int | None = Field(None, description="Chain ID of the blockchain network")
     routingStrategy: Literal["ensowallet", "router", "delegate"] | None = Field(
         None, description="Routing strategy to use"
     )
 
 
 class EnsoWalletApproveOutput(BaseModel):
-    """
-    Output model for approve token for the wallet.
-    """
+    """Output model for approve token for the wallet."""
 
     gas: str | None = Field(None, description="The gas estimate for the transaction")
     token: str | None = Field(None, description="The token address to approve")
@@ -239,133 +175,82 @@ class EnsoWalletApproveOutput(BaseModel):
 
 
 class EnsoWalletApproveArtifact(BaseModel):
-    """
-    Output model for approve token for the wallet.
-    """
+    """Artifact returned after broadcasting an approval transaction."""
 
-    tx: object | None = Field(None, description="The tx object to use in `ethers`")
+    tx: object | None = Field(
+        None, description="The transaction object to use in `ethers`"
+    )
     txHash: str | None = Field(None, description="The transaction hash")
 
 
 class EnsoWalletApprove(EnsoBaseTool):
-    """
-    This tool is used specifically for broadcasting a ERC20 token spending approval transaction to the network.
-    It should only be used when the user explicitly requests to broadcast an approval transaction with a specific amount for a certain token.
-
-    **Example Usage:**
-
-    "Broadcast an approval transaction for 10 USDC to the wallet."
-
-    **Important:**
-    - This tool should be used with extreme caution.
-    - Approving token spending grants another account permission to spend your tokens.
-
-    Attributes:
-        name (str): Name of the tool, specifically "enso_wallet_approve".
-        description (str): Comprehensive description of the tool's purpose and functionality.
-        args_schema (Type[BaseModel]): Schema for input arguments, specifying expected parameters.
-    """
+    """Broadcast an ERC20 token spending approval transaction."""
 
     name: str = "enso_wallet_approve"
-    description: str = "This tool is used specifically for broadcasting a ERC20 token spending approval transaction to the network. It should only be used when the user explicitly requests to broadcast an approval transaction with a specific amount for a certain token."
+    description: str = (
+        "This tool is used specifically for broadcasting a ERC20 token spending approval transaction to the "
+        "network. It should only be used when the user explicitly requests to broadcast an approval transaction "
+        "with a specific amount for a certain token."
+    )
     args_schema: Type[BaseModel] = EnsoWalletApproveInput
     response_format: str = "content_and_artifact"
-
-    # def _run(
-    #     self,
-    #     tokenAddress: str,
-    #     amount: int,
-    #     chainId: int = default_chain_id,
-    #     **kwargs,
-    # ) -> Tuple[EnsoBroadcastWalletApproveOutput, EnsoBroadcastWalletApproveArtifact]:
-    #     """Run the tool to approve enso router for a wallet.
-
-    #     Returns:
-    #         Tuple[EnsoBroadcastWalletApproveOutput, EnsoBroadcastWalletApproveArtifact]: A structured output containing the result of token approval.
-
-    #     Raises:
-    #         Exception: If there's an error accessing the Enso API.
-    #     """
-    #     raise NotImplementedError("Use _arun instead")
 
     async def _arun(
         self,
         tokenAddress: str,
         amount: int,
-        chainId: int = default_chain_id,
-        **kwargs,
+        chainId: int | None = None,
+        routingStrategy: Literal["ensowallet", "router", "delegate"] | None = None,
+        **_: object,
     ) -> Tuple[EnsoWalletApproveOutput, EnsoWalletApproveArtifact]:
-        """
-        Run the tool to approve enso router for a wallet.
-
-        Args:
-            tokenAddress (str): ERC20 token address of the token to approve.
-            amount (int): Amount of tokens to approve in wei.
-            chainId (int): Chain ID of the blockchain network.
-            **kwargs: optional kwargs for the tool with args schema defined in EnsoGetApproveInput.
-
-        Returns:
-            Tuple[EnsoBroadcastWalletApproveOutput, EnsoBroadcastWalletApproveArtifact]: The list of approve transaction output or an error message.
-        """
-        url = f"{base_url}/api/v1/wallet/approve"
         context = self.get_context()
+        resolved_chain_id = self.resolve_chain_id(context, chainId)
         api_token = self.get_api_token(context)
-        account = await self.get_account(context)
+        wallet_address = await self.get_wallet_address(context)
 
         headers = {
             "accept": "application/json",
             "Authorization": f"Bearer {api_token}",
         }
 
-        from_address = account.address
-
         params = EnsoWalletApproveInput(
             tokenAddress=tokenAddress,
             amount=amount,
-            chainId=chainId,
-        )
+            chainId=resolved_chain_id,
+            routingStrategy=routingStrategy,
+        ).model_dump(exclude_none=True)
+        params["fromAddress"] = wallet_address
 
-        if kwargs.get("routingStrategy"):
-            params.routingStrategy = kwargs["routingStrategy"]
-
-        params = params.model_dump(exclude_none=True)
-
-        params["fromAddress"] = from_address
-
-        with httpx.Client() as client:
+        async with httpx.AsyncClient() as client:
             try:
-                # Send the GET request
-                response = client.get(url, headers=headers, params=params)
+                response = await client.get(
+                    f"{base_url}/api/v1/wallet/approve",
+                    headers=headers,
+                    params=params,
+                )
                 response.raise_for_status()
 
-                # Map the response JSON into the WalletApproveTransaction model
                 json_dict = response.json()
                 content = EnsoWalletApproveOutput(**json_dict)
                 artifact = EnsoWalletApproveArtifact(**json_dict)
 
-                # Use the wallet provider to send the transaction
                 wallet_provider = await self.get_wallet_provider(context)
-
-                # Extract transaction data from the Enso API response
                 tx_data = json_dict.get("tx", {})
                 if tx_data:
-                    # Send the transaction using the wallet provider
                     tx_hash = wallet_provider.send_transaction(
                         {
                             "to": tx_data.get("to"),
                             "data": tx_data.get("data", "0x"),
                             "value": tx_data.get("value", 0),
+                            "from": wallet_address,
                         }
                     )
 
-                    # Wait for transaction confirmation
                     wallet_provider.wait_for_transaction_receipt(tx_hash)
                     artifact.txHash = tx_hash
                 else:
-                    # For now, return without executing the transaction if no tx data
                     artifact.txHash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
-                # Return the parsed response
                 return (content, artifact)
             except httpx.RequestError as req_err:
                 raise ToolException(
@@ -375,5 +260,5 @@ class EnsoWalletApprove(EnsoBaseTool):
                 raise ToolException(
                     f"http error from Enso API: {http_err}"
                 ) from http_err
-            except Exception as e:
-                raise ToolException(f"error from Enso API: {e}") from e
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ToolException(f"error from Enso API: {exc}") from exc


### PR DESCRIPTION
## Summary
- update Enso base helper to resolve API token, wallet address, and agent network defaults, and add amount formatting helper
- refactor Enso skills to rely on wallet provider/address, resolve chain IDs from the agent config, and harden data handling
- make Enso skill config main token list optional and clean up imports

## Testing
- uv run ruff format
- uv run ruff check --fix
- uv run pytest *(fails: package imports are unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3602ddf24832fb6937e3742fd1af4