### PR TITLE
chore: align skill schema tags

### DIFF
--- a/intentkit/skills/acolyt/schema.json
+++ b/intentkit/skills/acolyt/schema.json
@@ -5,8 +5,9 @@
   "description": "Integration with Acolyt Oracle providing blockchain oracle services for accessing and verifying off-chain data with secure API connections",
   "x-icon": "https://ai.service.crestal.dev/skills/acolyt/acolyt.jpg",
   "x-tags": [
-    "Blockchain",
-    "Oracle"
+    "Analytics",
+    "Crypto",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/aixbt/schema.json
+++ b/intentkit/skills/aixbt/schema.json
@@ -5,9 +5,9 @@
   "description": "Cryptocurrency project data and analytics through the AIXBT API",
   "x-icon": "https://ai.service.crestal.dev/skills/aixbt/aixbt.jpg",
   "x-tags": [
-    "Cryptocurrency",
-    "Research",
-    "Analytics"
+    "Analytics",
+    "Crypto",
+    "Knowledge Base"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/allora/schema.json
+++ b/intentkit/skills/allora/schema.json
@@ -5,7 +5,8 @@
   "description": "Integration with Allora API for blockchain-based price predictions and market forecasting services via Upshot's prediction markets",
   "x-icon": "https://ai.service.crestal.dev/skills/allora/allora.jpeg",
   "x-tags": [
-    "Blockchain"
+    "Analytics",
+    "Crypto"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/basename/schema.json
+++ b/intentkit/skills/basename/schema.json
@@ -5,7 +5,8 @@
   "description": "Basename ENS-style name registration via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/basename/basename.svg",
   "x-tags": [
-    "Blockchain"
+    "Crypto",
+    "Identity"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/carv/schema.json
+++ b/intentkit/skills/carv/schema.json
@@ -1,137 +1,134 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "CARV",
-    "description": "Configuration for the CARV skill.",
-    "type": "object",
-    "x-icon": "https://ai.service.crestal.dev/skills/carv/carv.webp",
-    "x-tags": [
-        "AI",
-        "Data",
-        "Information",
-        "Analytics",
-        "Market Data"
-    ],
-    "properties": {
-        "enabled": {
-            "type": "boolean",
-            "description": "Enable or disable the CARV skill.",
-            "default": false
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CARV",
+  "description": "Configuration for the CARV skill.",
+  "type": "object",
+  "x-icon": "https://ai.service.crestal.dev/skills/carv/carv.webp",
+  "x-tags": [
+    "Analytics",
+    "Crypto"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Enable or disable the CARV skill.",
+      "default": false
+    },
+    "states": {
+      "type": "object",
+      "title": "Skill States",
+      "description": "Enable/disable specific tools for CARV",
+      "properties": {
+        "onchain_query": {
+          "type": "string",
+          "title": "On-Chain Query",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "allows you to use the nature language to query the on-chain data. Behind the scean, CARV will use LLM model to interpreate the nature language input and convert into the sql query based on the above schemas",
+          "default": "public"
         },
-        "states": {
-            "type": "object",
-            "title": "Skill States",
-            "description": "Enable/disable specific tools for CARV",
-            "properties": {
-                "onchain_query": {
-                    "type": "string",
-                    "title": "On-Chain Query",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "allows you to use the nature language to query the on-chain data. Behind the scean, CARV will use LLM model to interpreate the nature language input and convert into the sql query based on the above schemas",
-                    "default": "public"
-                },
-                "token_info_and_price": {
-                    "type": "string",
-                    "title": "Token Information and Price",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Fetches detailed information and current USD price of a cryptocurrency token from CARV API using its ticker symbol (e.g., 'eth', 'btc'), returning metadata like name, symbol, platform, categories, and contract addresses, useful for understanding its identity, ecosystem, market value, and for obtaining comprehensive token data with live pricing.",
-                    "default": "public"
-                },
-                "fetch_news": {
-                    "type": "string",
-                    "title": "Fetch News",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "retrieves a list of recent news items, each including a title, URL, and a short description",
-                    "default": "disabled"
-                }
-            }
+        "token_info_and_price": {
+          "type": "string",
+          "title": "Token Information and Price",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Fetches detailed information and current USD price of a cryptocurrency token from CARV API using its ticker symbol (e.g., 'eth', 'btc'), returning metadata like name, symbol, platform, categories, and contract addresses, useful for understanding its identity, ecosystem, market value, and for obtaining comprehensive token data with live pricing.",
+          "default": "public"
         },
-        "api_key_provider": {
-            "type": "string",
-            "title": "API Key Provider",
-            "description": "Provider of the API key",
-            "enum": [
-                "agent_owner",
-                "platform"
-            ],
-            "x-enum-title": [
-                "Owner Provided",
-                "Nation Hosted"
-            ],
-            "default": "platform"
+        "fetch_news": {
+          "type": "string",
+          "title": "Fetch News",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "retrieves a list of recent news items, each including a title, URL, and a short description",
+          "default": "disabled"
         }
+      }
+    },
+    "api_key_provider": {
+      "type": "string",
+      "title": "API Key Provider",
+      "description": "Provider of the API key",
+      "enum": [
+        "agent_owner",
+        "platform"
+      ],
+      "x-enum-title": [
+        "Owner Provided",
+        "Nation Hosted"
+      ],
+      "default": "platform"
+    }
+  },
+  "required": [
+    "enabled",
+    "states"
+  ],
+  "if": {
+    "allOf": [
+      {
+        "properties": {
+          "enabled": {
+            "const": true
+          }
+        }
+      },
+      {
+        "properties": {
+          "api_key_provider": {
+            "const": "agent_owner"
+          }
+        }
+      }
+    ]
+  },
+  "then": {
+    "properties": {
+      "api_key": {
+        "type": "string",
+        "title": "CARV API Key",
+        "x-link": "[Get your API key](https://docs.carv.io/d.a.t.a.-ai-framework/api-documentation#authentication)",
+        "x-sensitive": true,
+        "description": "API Key for authenticating with the CARV API."
+      },
+      "rate_limit_number": {
+        "type": "integer",
+        "title": "Rate Limit Number",
+        "description": "Number of requests allowed per time window."
+      },
+      "rate_limit_minutes": {
+        "type": "integer",
+        "title": "Rate Limit Minutes",
+        "description": "Time window in minutes for rate limiting."
+      }
     },
     "required": [
-        "enabled",
-        "states"
-    ],
-    "if": {
-        "allOf": [
-            {
-                "properties": {
-                    "enabled": {
-                        "const": true
-                    }
-                }
-            },
-            {
-                "properties": {
-                    "api_key_provider": {
-                        "const": "agent_owner"
-                    }
-                }
-            }
-        ]
-    },
-    "then": {
-        "properties": {
-            "api_key": {
-                "type": "string",
-                "title": "CARV API Key",
-                "x-link": "[Get your API key](https://docs.carv.io/d.a.t.a.-ai-framework/api-documentation#authentication)",
-                "x-sensitive": true,
-                "description": "API Key for authenticating with the CARV API."
-            },
-            "rate_limit_number": {
-                "type": "integer",
-                "title": "Rate Limit Number",
-                "description": "Number of requests allowed per time window."
-            },
-            "rate_limit_minutes": {
-                "type": "integer",
-                "title": "Rate Limit Minutes",
-                "description": "Time window in minutes for rate limiting."
-            }
-        },
-        "required": [
-            "api_key"
-        ]
-    },
-    "additionalProperties": true
+      "api_key"
+    ]
+  },
+  "additionalProperties": true
 }

--- a/intentkit/skills/casino/schema.json
+++ b/intentkit/skills/casino/schema.json
@@ -5,7 +5,6 @@
   "description": "Casino gaming skills including card decks and quantum dice rolling for interactive games with users",
   "x-icon": "https://ai.service.crestal.dev/skills/casino/casino.png",
   "x-tags": [
-    "Gaming",
     "Entertainment"
   ],
   "properties": {

--- a/intentkit/skills/cdp/schema.json
+++ b/intentkit/skills/cdp/schema.json
@@ -5,7 +5,8 @@
   "description": "Integration with Coinbase Wallet (CDP) providing blockchain wallet functionality including balance checking and native transfers",
   "x-icon": "https://ai.service.crestal.dev/skills/cdp/cdp.png",
   "x-tags": [
-    "Blockchain"
+    "Crypto",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/chainlist/schema.json
+++ b/intentkit/skills/chainlist/schema.json
@@ -5,10 +5,8 @@
   "description": "Access blockchain RPC endpoints and network information from chainlist.org. Enable this skill to look up EVM-compatible networks by name, symbol, or chain ID and get their RPC endpoints, native currencies, and explorer links.",
   "x-icon": "https://ai.service.crestal.dev/skills/chainlist/chainlist.png",
   "x-tags": [
-    "Blockchain",
-    "RPC",
-    "EVM",
-    "Network"
+    "Crypto",
+    "Infrastructure"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/common/schema.json
+++ b/intentkit/skills/common/schema.json
@@ -5,7 +5,7 @@
   "description": "Utility skills",
   "x-icon": "https://ai.service.crestal.dev/skills/common/common.jpg",
   "x-tags": [
-    "Utility"
+    "Infrastructure"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/cookiefun/schema.json
+++ b/intentkit/skills/cookiefun/schema.json
@@ -5,10 +5,8 @@
   "description": "Access Twitter/X analytics and insights using CookieFun API. Get data about accounts, tweets, followers, and trends across different industry sectors.",
   "x-icon": "https://ai.service.crestal.dev/skills/cookiefun/cookiefun.png",
   "x-tags": [
-    "Twitter",
-    "Social Media",
     "Analytics",
-    "X"
+    "Communication"
   ],
   "x-nft-requirement": 10,
   "properties": {

--- a/intentkit/skills/cryptocompare/schema.json
+++ b/intentkit/skills/cryptocompare/schema.json
@@ -5,8 +5,8 @@
   "description": "Integration with CryptoCompare API providing cryptocurrency market data, price information, and crypto news with rate limiting capabilities",
   "x-icon": "https://ai.service.crestal.dev/skills/cryptocompare/cryptocompare.png",
   "x-tags": [
-    "Blockchain",
-    "Finance"
+    "Analytics",
+    "Crypto"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/cryptopanic/schema.json
+++ b/intentkit/skills/cryptopanic/schema.json
@@ -5,7 +5,9 @@
   "description": "CryptoPanic is a news aggregator platform indicating impact on price and market for traders and cryptocurrency enthusiasts.",
   "x-icon": "https://ai.service.crestal.dev/skills/cryptopanic/cryptopanic.png",
   "x-tags": [
-    "Data"
+    "Analytics",
+    "Crypto",
+    "Knowledge Base"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/dapplooker/schema.json
+++ b/intentkit/skills/dapplooker/schema.json
@@ -5,10 +5,8 @@
   "description": "Retrieve comprehensive market data and analytics for AI agent tokens using DappLooker. This API specializes in AI-focused crypto projects and may not provide data for general cryptocurrencies like BTC or ETH.",
   "x-icon": "https://ai.service.crestal.dev/skills/dapplooker/dapplooker.jpg",
   "x-tags": [
-    "Crypto",
-    "Market Data",
-    "Token Metrics",
-    "AI Agents"
+    "Analytics",
+    "Crypto"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/defillama/schema.json
+++ b/intentkit/skills/defillama/schema.json
@@ -379,5 +379,9 @@
   "required": [
     "states",
     "enabled"
+  ],
+  "x-tags": [
+    "Analytics",
+    "DeFi"
   ]
 }

--- a/intentkit/skills/dexscreener/schema.json
+++ b/intentkit/skills/dexscreener/schema.json
@@ -1,93 +1,91 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Dexscreener",
-    "description": "Integration with DexScreener API, enabling crypto token pair information",
-    "type": "object",
-    "x-icon": "https://ai.service.crestal.dev/skills/dexscreener/dexscreener.png",
-    "x-tags": [
-        "Crypto",
-        "Market Data",
-        "Finance",
-        "Blockchain"
-    ],
-    "properties": {
-        "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "description": "Enable or disable the Dexscreener skill.",
-            "default": false
-        },
-        "states": {
-            "type": "object",
-            "title": "Skill States",
-            "description": "Enable/disable specific tools. Only enable one if you want a consistent characteristic for your agent",
-            "properties": {
-                "search_token": {
-                    "type": "string",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Searches on DexScreener for token pairs matching a query (symbol, name, address). Returns up to 25 pairs sorted by 'liquidity' or 'volume' with timeframe options, including price, volume, etc. Use this tool to find token information based on user queries.",
-                    "default": "disabled"
-                },
-                "get_pair_info": {
-                    "type": "string",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Retrieves detailed information about a specific trading pair using chain ID and pair address. Returns comprehensive data including current price, volume, liquidity, price changes, market cap, FDV, transaction counts, and social links.",
-                    "default": "disabled"
-                },
-                "get_token_pairs": {
-                    "type": "string",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Finds all trading pairs for a specific token using chain ID and token address. Returns a list of all pools/pairs where this token is traded, including pair addresses, DEX information, liquidity, volume, and pricing data for each pair.",
-                    "default": "disabled"
-                },
-                "get_tokens_info": {
-                    "type": "string",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Retrieves detailed trading pair information for multiple tokens (up to 30) using chain ID and a list of token addresses. More efficient than making individual calls when you need info for multiple tokens. Use for portfolio analysis or comparing multiple tokens at once.",
-                    "default": "disabled"
-                }
-            }
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Dexscreener",
+  "description": "Integration with DexScreener API, enabling crypto token pair information",
+  "type": "object",
+  "x-icon": "https://ai.service.crestal.dev/skills/dexscreener/dexscreener.png",
+  "x-tags": [
+    "Analytics",
+    "DeFi"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Enable or disable the Dexscreener skill.",
+      "default": false
     },
-    "required": [
-        "enabled",
-        "states"
-    ],
-    "additionalProperties": true
+    "states": {
+      "type": "object",
+      "title": "Skill States",
+      "description": "Enable/disable specific tools. Only enable one if you want a consistent characteristic for your agent",
+      "properties": {
+        "search_token": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Searches on DexScreener for token pairs matching a query (symbol, name, address). Returns up to 25 pairs sorted by 'liquidity' or 'volume' with timeframe options, including price, volume, etc. Use this tool to find token information based on user queries.",
+          "default": "disabled"
+        },
+        "get_pair_info": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Retrieves detailed information about a specific trading pair using chain ID and pair address. Returns comprehensive data including current price, volume, liquidity, price changes, market cap, FDV, transaction counts, and social links.",
+          "default": "disabled"
+        },
+        "get_token_pairs": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Finds all trading pairs for a specific token using chain ID and token address. Returns a list of all pools/pairs where this token is traded, including pair addresses, DEX information, liquidity, volume, and pricing data for each pair.",
+          "default": "disabled"
+        },
+        "get_tokens_info": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Retrieves detailed trading pair information for multiple tokens (up to 30) using chain ID and a list of token addresses. More efficient than making individual calls when you need info for multiple tokens. Use for portfolio analysis or comparing multiple tokens at once.",
+          "default": "disabled"
+        }
+      }
+    }
+  },
+  "required": [
+    "enabled",
+    "states"
+  ],
+  "additionalProperties": true
 }

--- a/intentkit/skills/dune_analytics/schema.json
+++ b/intentkit/skills/dune_analytics/schema.json
@@ -95,5 +95,10 @@
       ]
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "x-tags": [
+    "Analytics",
+    "Crypto",
+    "Knowledge Base"
+  ]
 }

--- a/intentkit/skills/elfa/schema.json
+++ b/intentkit/skills/elfa/schema.json
@@ -5,7 +5,8 @@
   "description": "Integration with Elfa AI API providing data analysis and processing capabilities with secure authentication for advanced data operations",
   "x-icon": "https://ai.service.crestal.dev/skills/elfa/elfa.jpg",
   "x-tags": [
-    "Data"
+    "AI",
+    "Analytics"
   ],
   "x-nft-requirement": 1,
   "properties": {

--- a/intentkit/skills/enso/schema.json
+++ b/intentkit/skills/enso/schema.json
@@ -5,7 +5,8 @@
   "description": "Integration with Enso Finance API providing DeFi trading and portfolio management capabilities across multiple blockchain networks",
   "x-icon": "https://ai.service.crestal.dev/skills/enso/enso.jpg",
   "x-tags": [
-    "Blockchain"
+    "Analytics",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/erc20/schema.json
+++ b/intentkit/skills/erc20/schema.json
@@ -5,7 +5,8 @@
   "description": "ERC20 token balance and transfer actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/erc20/erc20.svg",
   "x-tags": [
-    "Blockchain"
+    "Crypto",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/erc721/schema.json
+++ b/intentkit/skills/erc721/schema.json
@@ -5,7 +5,8 @@
   "description": "ERC721 NFT management actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/erc721/erc721.svg",
   "x-tags": [
-    "Blockchain"
+    "Crypto",
+    "NFT"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/firecrawl/schema.json
+++ b/intentkit/skills/firecrawl/schema.json
@@ -5,11 +5,7 @@
   "description": "AI-powered web scraping and crawling capabilities using Firecrawl",
   "x-icon": "https://ai.service.crestal.dev/skills/firecrawl/firecrawl.png",
   "x-tags": [
-    "Web Scraping",
-    "Crawling",
-    "Content Extraction",
-    "Data Mining",
-    "Website Analysis"
+    "Knowledge Base"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/github/schema.json
+++ b/intentkit/skills/github/schema.json
@@ -5,9 +5,8 @@
   "description": "Search capabilities for GitHub repositories, users, and code",
   "x-icon": "https://ai.service.crestal.dev/skills/github/github.jpg",
   "x-tags": [
-    "GitHub",
-    "Search",
-    "Code"
+    "Developer Tools",
+    "Search"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/heurist/schema.json
+++ b/intentkit/skills/heurist/schema.json
@@ -6,7 +6,7 @@
   "x-icon": "https://ai.service.crestal.dev/skills/heurist/heurist.png",
   "x-tags": [
     "AI",
-    "Image Generation"
+    "Image"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/http/schema.json
+++ b/intentkit/skills/http/schema.json
@@ -5,10 +5,9 @@
   "description": "HTTP client skills for making web requests",
   "x-icon": "https://ai.service.crestal.dev/skills/http/http.svg",
   "x-tags": [
-    "HTTP",
-    "Web",
-    "API",
-    "Client"
+    "Developer Tools",
+    "Infrastructure",
+    "Knowledge Base"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/lifi/schema.json
+++ b/intentkit/skills/lifi/schema.json
@@ -5,10 +5,7 @@
   "description": "Cross-chain token transfer and swap capabilities using the LiFi protocol",
   "x-icon": "https://ai.service.crestal.dev/skills/lifi/lifi.png",
   "x-tags": [
-    "DeFi",
-    "Blockchain",
-    "Token Transfer",
-    "Cross-chain"
+    "DeFi"
   ],
   "properties": {
     "enabled": {
@@ -53,7 +50,10 @@
           "description": "Execute token transfers (requires CDP wallet and cdp skills enabled)"
         }
       },
-      "required": ["token_quote", "token_execute"],
+      "required": [
+        "token_quote",
+        "token_execute"
+      ],
       "description": "States for each LiFi skill"
     },
     "default_slippage": {
@@ -71,7 +71,13 @@
       "description": "List of blockchain networks that can be used (if empty, all supported chains are allowed)",
       "items": {
         "type": "string",
-        "examples": ["ETH", "POL", "ARB", "OPT", "DAI"]
+        "examples": [
+          "ETH",
+          "POL",
+          "ARB",
+          "OPT",
+          "DAI"
+        ]
       },
       "uniqueItems": true
     },
@@ -84,6 +90,9 @@
       "maximum": 1800
     }
   },
-  "required": ["states", "enabled"],
+  "required": [
+    "states",
+    "enabled"
+  ],
   "additionalProperties": true
-} 
+}

--- a/intentkit/skills/moralis/schema.json
+++ b/intentkit/skills/moralis/schema.json
@@ -152,5 +152,10 @@
       ]
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "x-tags": [
+    "Analytics",
+    "Crypto",
+    "DeFi"
+  ]
 }

--- a/intentkit/skills/morpho/schema.json
+++ b/intentkit/skills/morpho/schema.json
@@ -5,7 +5,7 @@
   "description": "Morpho lending actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/morpho/morpho.svg",
   "x-tags": [
-    "Blockchain"
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/nation/schema.json
+++ b/intentkit/skills/nation/schema.json
@@ -5,8 +5,9 @@
   "description": "Check nation NFT stats",
   "x-icon": "https://ai.service.crestal.dev/skills/nation/nation.png",
   "x-tags": [
-    "Nation",
-    "NFTChecker"
+    "Analytics",
+    "Crypto",
+    "NFT"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/openai/schema.json
+++ b/intentkit/skills/openai/schema.json
@@ -6,8 +6,7 @@
   "x-icon": "https://ai.service.crestal.dev/skills/openai/openai.png",
   "x-tags": [
     "AI",
-    "Image Generation",
-    "Image Analysis"
+    "Image"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/portfolio/schema.json
+++ b/intentkit/skills/portfolio/schema.json
@@ -5,11 +5,9 @@
   "description": "Access blockchain wallet data and analytics through Moralis APIs for portfolio tracking, token balances, and investment performance",
   "x-icon": "https://ai.service.crestal.dev/skills/portfolio/moralis.png",
   "x-tags": [
-    "Blockchain",
-    "Web3",
+    "Analytics",
     "Crypto",
-    "Portfolio",
-    "Wallet"
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/pyth/schema.json
+++ b/intentkit/skills/pyth/schema.json
@@ -5,7 +5,9 @@
   "description": "Pyth oracle price data via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/pyth/pyth.svg",
   "x-tags": [
-    "Blockchain"
+    "Analytics",
+    "Crypto",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/slack/schema.json
+++ b/intentkit/skills/slack/schema.json
@@ -5,7 +5,7 @@
   "description": "Integration with Slack API enabling workspace communication including channel management, message retrieval, and posting capabilities for team collaboration",
   "x-icon": "https://ai.service.crestal.dev/skills/slack/slack.jpg",
   "x-tags": [
-    "Social"
+    "Communication"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/supabase/schema.json
+++ b/intentkit/skills/supabase/schema.json
@@ -5,8 +5,7 @@
   "description": "Integration with Supabase backend-as-a-service platform enabling database operations and Edge Function invocations",
   "x-icon": "https://ai.service.crestal.dev/skills/supabase/supabase.svg",
   "x-tags": [
-    "Database",
-    "Backend"
+    "Infrastructure"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/superfluid/schema.json
+++ b/intentkit/skills/superfluid/schema.json
@@ -5,7 +5,7 @@
   "description": "Superfluid streaming actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/superfluid/superfluid.svg",
   "x-tags": [
-    "Blockchain"
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/system/schema.json
+++ b/intentkit/skills/system/schema.json
@@ -5,9 +5,7 @@
   "description": "System management and configuration skills for agent operations including API key management",
   "x-icon": "https://ai.service.crestal.dev/skills/system/system.svg",
   "x-tags": [
-    "System",
-    "Management",
-    "Configuration"
+    "Infrastructure"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/tavily/schema.json
+++ b/intentkit/skills/tavily/schema.json
@@ -5,10 +5,8 @@
   "description": "Web search and content extraction capabilities using Tavily",
   "x-icon": "https://ai.service.crestal.dev/skills/tavily/tavily.jpg",
   "x-tags": [
-    "Internet",
-    "Search",
-    "Information",
-    "Content Extraction"
+    "Knowledge Base",
+    "Search"
   ],
   "x-nft-requirement": 1,
   "properties": {

--- a/intentkit/skills/token/schema.json
+++ b/intentkit/skills/token/schema.json
@@ -5,11 +5,8 @@
   "type": "object",
   "x-icon": "https://ai.service.crestal.dev/skills/portfolio/moralis.png",
   "x-tags": [
-    "Blockchain",
-    "Web3",
-    "Crypto",
-    "Token",
-    "DeFi"
+    "Analytics",
+    "Crypto"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/twitter/schema.json
+++ b/intentkit/skills/twitter/schema.json
@@ -5,7 +5,7 @@
   "description": "Integration with X API enabling social media interactions including retrieving posts, mentions, user information, and posting content with media support",
   "x-icon": "https://ai.service.crestal.dev/skills/twitter/twitter.png",
   "x-tags": [
-    "Social"
+    "Communication"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/unrealspeech/schema.json
+++ b/intentkit/skills/unrealspeech/schema.json
@@ -5,10 +5,7 @@
   "description": "Convert text to natural-sounding speech with various voices and customization options",
   "x-icon": "https://ai.service.crestal.dev/skills/unrealspeech/unrealspeech.jpg",
   "x-tags": [
-    "Audio",
-    "Speech",
-    "Text-to-Speech",
-    "Voice"
+    "Audio"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/venice_audio/schema.json
+++ b/intentkit/skills/venice_audio/schema.json
@@ -1,152 +1,151 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Venice Audio Skills",
-    "x-icon": "https://ai.service.crestal.dev/skills/venice_audio/venice_audio.jpg",
-    "description": "Configuration for the Venice Audio skill.",
-    "type": "object",
-    "x-tags": [
-        "AI",
-        "Audio",
-        "Text to Speech"
-    ],
-    "properties": {
-        "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "description": "Enable or disable the Venice Audio skill.",
-            "default": false
-        },
-        "voice_model": {
-            "type": "string",
-            "title": "Voice Model",
-            "x-link": "[Listen Voice Example](https://huggingface.co/spaces/hexgrad/Kokoro-TTS)",
-            "enum": [
-                "af_heart",
-                "bm_lewis",
-                "custom"
-            ],
-            "x-enum-title": [
-                "af_heart (default female)",
-                "bm_lewis (default male)",
-                "Custom"
-            ],
-            "description": "Text to speech tool",
-            "default": "af_heart"
-        },
-        "states": {
-            "type": "object",
-            "title": "Skill States",
-            "description": "Enable/disable specific voice models. Only enable one if you want a consistent characteristic for your agent. See docs for voice details and quality grades.",
-            "properties": {
-                "text_to_speech": {
-                    "type": "string",
-                    "title": "Text to Speech",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Text to speech tool",
-                    "default": "disabled"
-                }
-            }
-        },
-        "api_key_provider": {
-            "type": "string",
-            "title": "API Key Provider",
-            "description": "Provider of the API key",
-            "enum": [
-                "agent_owner"
-            ],
-            "x-enum-title": [
-                "Owner Provided"
-            ],
-            "default": "agent_owner"
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Venice Audio Skills",
+  "x-icon": "https://ai.service.crestal.dev/skills/venice_audio/venice_audio.jpg",
+  "description": "Configuration for the Venice Audio skill.",
+  "type": "object",
+  "x-tags": [
+    "AI",
+    "Audio"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Enable or disable the Venice Audio skill.",
+      "default": false
     },
-    "required": [
-        "states",
-        "enabled"
-    ],
-    "allOf": [
-        {
-            "if": {
-                "properties": {
-                    "voice_model": {
-                        "const": "custom"
-                    }
-                }
-            },
-            "then": {
-                "properties": {
-                    "voice_model_custom": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "title": "Voice Model (Custom)",
-                        "x-link": "[Supported Voice Model](https://docs.venice.ai/api-reference/endpoint/audio/speech#body-voice)",
-                        "description": "You can add one or more custom voice models.",
-                        "default": [
-                            "af_heart",
-                            "bm_lewis"
-                        ]
-                    }
-                },
-                "required": [
-                    "voice_model_custom"
-                ]
-            }
-        },
-        {
-            "if": {
-                "allOf": [
-                    {
-                        "properties": {
-                            "enabled": {
-                                "const": true
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "api_key_provider": {
-                                "const": "agent_owner"
-                            }
-                        }
-                    }
-                ]
-            },
-            "then": {
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "title": "Venice API Key",
-                        "x-link": "[Get your API key](https://venice.ai/)",
-                        "x-sensitive": true,
-                        "description": "API Key for authenticating with the Venice AI API."
-                    },
-                    "rate_limit_number": {
-                        "type": "integer",
-                        "title": "Rate Limit Number",
-                        "description": "Number of requests allowed per time window."
-                    },
-                    "rate_limit_minutes": {
-                        "type": "integer",
-                        "title": "Rate Limit Minutes",
-                        "description": "Time window in minutes for rate limiting."
-                    }
-                },
-                "required": [
-                    "api_key"
-                ]
-            }
+    "voice_model": {
+      "type": "string",
+      "title": "Voice Model",
+      "x-link": "[Listen Voice Example](https://huggingface.co/spaces/hexgrad/Kokoro-TTS)",
+      "enum": [
+        "af_heart",
+        "bm_lewis",
+        "custom"
+      ],
+      "x-enum-title": [
+        "af_heart (default female)",
+        "bm_lewis (default male)",
+        "Custom"
+      ],
+      "description": "Text to speech tool",
+      "default": "af_heart"
+    },
+    "states": {
+      "type": "object",
+      "title": "Skill States",
+      "description": "Enable/disable specific voice models. Only enable one if you want a consistent characteristic for your agent. See docs for voice details and quality grades.",
+      "properties": {
+        "text_to_speech": {
+          "type": "string",
+          "title": "Text to Speech",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Text to speech tool",
+          "default": "disabled"
         }
-    ],
-    "additionalProperties": true
+      }
+    },
+    "api_key_provider": {
+      "type": "string",
+      "title": "API Key Provider",
+      "description": "Provider of the API key",
+      "enum": [
+        "agent_owner"
+      ],
+      "x-enum-title": [
+        "Owner Provided"
+      ],
+      "default": "agent_owner"
+    }
+  },
+  "required": [
+    "states",
+    "enabled"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "voice_model": {
+            "const": "custom"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "voice_model_custom": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Voice Model (Custom)",
+            "x-link": "[Supported Voice Model](https://docs.venice.ai/api-reference/endpoint/audio/speech#body-voice)",
+            "description": "You can add one or more custom voice models.",
+            "default": [
+              "af_heart",
+              "bm_lewis"
+            ]
+          }
+        },
+        "required": [
+          "voice_model_custom"
+        ]
+      }
+    },
+    {
+      "if": {
+        "allOf": [
+          {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          {
+            "properties": {
+              "api_key_provider": {
+                "const": "agent_owner"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "title": "Venice API Key",
+            "x-link": "[Get your API key](https://venice.ai/)",
+            "x-sensitive": true,
+            "description": "API Key for authenticating with the Venice AI API."
+          },
+          "rate_limit_number": {
+            "type": "integer",
+            "title": "Rate Limit Number",
+            "description": "Number of requests allowed per time window."
+          },
+          "rate_limit_minutes": {
+            "type": "integer",
+            "title": "Rate Limit Minutes",
+            "description": "Time window in minutes for rate limiting."
+          }
+        },
+        "required": [
+          "api_key"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": true
 }

--- a/intentkit/skills/venice_image/schema.json
+++ b/intentkit/skills/venice_image/schema.json
@@ -6,7 +6,7 @@
   "x-icon": "https://ai.service.crestal.dev/skills/venice_image/venice_image.jpg",
   "x-tags": [
     "AI",
-    "Image Generation"
+    "Image"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/web_scraper/schema.json
+++ b/intentkit/skills/web_scraper/schema.json
@@ -5,11 +5,7 @@
   "description": "Scrape web content and index it for intelligent querying and retrieval",
   "x-icon": "https://ai.service.crestal.dev/skills/web_scraper/langchain.png",
   "x-tags": [
-    "Web Scraping",
-    "Content Indexing",
-    "Vector Search",
-    "LangChain",
-    "Document Retrieval"
+    "Knowledge Base"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/weth/schema.json
+++ b/intentkit/skills/weth/schema.json
@@ -5,7 +5,8 @@
   "description": "Wrap ETH actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/weth/weth.svg",
   "x-tags": [
-    "Blockchain"
+    "Crypto",
+    "DeFi"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/wow/schema.json
+++ b/intentkit/skills/wow/schema.json
@@ -5,7 +5,7 @@
   "description": "WOW social token actions via Coinbase AgentKit",
   "x-icon": "https://ai.service.crestal.dev/skills/wow/wow.svg",
   "x-tags": [
-    "Blockchain"
+    "Crypto"
   ],
   "properties": {
     "enabled": {

--- a/intentkit/skills/xmtp/schema.json
+++ b/intentkit/skills/xmtp/schema.json
@@ -1,75 +1,73 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "title": "XMTP",
-    "description": "Use this skill only if you want make an XMTP Agent. XMTP protocol skills for creating blockchain transaction requests that can be sent to users for signing",
-    "x-icon": "https://ai.service.crestal.dev/skills/xmtp/xmtp.png",
-    "x-tags": [
-        "XMTP",
-        "Blockchain",
-        "Transactions",
-        "Web3",
-        "Base"
-    ],
-    "properties": {
-        "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "description": "Whether this skill is enabled",
-            "default": false
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "XMTP",
+  "description": "Use this skill only if you want make an XMTP Agent. XMTP protocol skills for creating blockchain transaction requests that can be sent to users for signing",
+  "x-icon": "https://ai.service.crestal.dev/skills/xmtp/xmtp.png",
+  "x-tags": [
+    "Communication",
+    "Crypto",
+    "DeFi"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Whether this skill is enabled",
+      "default": false
+    },
+    "states": {
+      "type": "object",
+      "properties": {
+        "xmtp_transfer": {
+          "type": "string",
+          "title": "XMTP Transfer",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Create XMTP transaction requests for transferring ETH or ERC20 tokens on Base mainnet. Supports both native ETH transfers and ERC20 token transfers. Generates wallet_sendCalls transaction data that users can sign.",
+          "default": "disabled"
         },
-        "states": {
-            "type": "object",
-            "properties": {
-                "xmtp_transfer": {
-                    "type": "string",
-                    "title": "XMTP Transfer",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Create XMTP transaction requests for transferring ETH or ERC20 tokens on Base mainnet. Supports both native ETH transfers and ERC20 token transfers. Generates wallet_sendCalls transaction data that users can sign.",
-                    "default": "disabled"
-                },
-                "xmtp_swap": {
-                    "type": "string",
-                    "title": "XMTP Swap",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Create XMTP transaction requests for swapping tokens on Base using CDP swap quote. Returns a wallet_sendCalls payload that can include an optional approval call and the swap call. Only supports base-mainnet and base-sepolia.",
-                    "default": "disabled"
-                },
-                "xmtp_get_swap_price": {
-                    "type": "string",
-                    "title": "XMTP Get Swap Price",
-                    "enum": [
-                        "disabled",
-                        "public",
-                        "private"
-                    ],
-                    "x-enum-title": [
-                        "Disabled",
-                        "Agent Owner + All Users",
-                        "Agent Owner Only"
-                    ],
-                    "description": "Get an indicative swap price/quote for token pair and amount on Base networks using CDP. Provides estimated output amounts for token swaps without creating transactions.",
-                    "default": "disabled"
-                }
-            }
+        "xmtp_swap": {
+          "type": "string",
+          "title": "XMTP Swap",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Create XMTP transaction requests for swapping tokens on Base using CDP swap quote. Returns a wallet_sendCalls payload that can include an optional approval call and the swap call. Only supports base-mainnet and base-sepolia.",
+          "default": "disabled"
+        },
+        "xmtp_get_swap_price": {
+          "type": "string",
+          "title": "XMTP Get Swap Price",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Get an indicative swap price/quote for token pair and amount on Base networks using CDP. Provides estimated output amounts for token swaps without creating transactions.",
+          "default": "disabled"
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
## Summary
- normalize each skill schema's `x-tags` to a 14-item shared taxonomy (AI, Analytics, Audio, Communication, Crypto, DeFi, Developer Tools, Entertainment, Identity, Image, Infrastructure, Knowledge Base, NFT, Search)
- replace legacy, brand-specific, and overlapping labels across every schema with the standardized categories

## Testing
- uv run ruff format
- uv run ruff check --fix

------
https://chatgpt.com/codex/tasks/task_b_68d8aeffa69c832fae0d633a47e6d7c6