### PR TITLE
Ensure AgentKit skills use context agent

### DIFF
--- a/intentkit/clients/__init__.py
+++ b/intentkit/clients/__init__.py
@@ -1,4 +1,4 @@
-from intentkit.clients.cdp import CdpClient, get_cdp_client
+from intentkit.clients.cdp import get_origin_cdp_client, get_wallet_provider
 from intentkit.clients.twitter import (
     TwitterClient,
     TwitterClientConfig,
@@ -10,7 +10,7 @@ __all__ = [
     "TwitterClient",
     "TwitterClientConfig",
     "get_twitter_client",
-    "CdpClient",
-    "get_cdp_client",
+    "get_origin_cdp_client",
+    "get_wallet_provider",
     "get_web3_client",
 ]

--- a/intentkit/core/agent.py
+++ b/intentkit/core/agent.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy import func, select, text, update
 
 from intentkit.abstracts.skill import SkillStoreABC
-from intentkit.clients.cdp import get_cdp_client
+from intentkit.clients.cdp import get_wallet_provider
 from intentkit.config.config import config
 from intentkit.models.agent import (
     Agent,
@@ -73,8 +73,7 @@ async def process_agent_wallet(
 
     # 4. Initialize wallet based on provider type
     if config.cdp_api_key_id and current_wallet_provider == "cdp":
-        cdp_client = await get_cdp_client(agent.id, agent_store)
-        await cdp_client.get_wallet_provider()
+        await get_wallet_provider(agent)
         agent_data = await AgentData.get(agent.id)
     elif current_wallet_provider == "readonly":
         agent_data = await AgentData.patch(

--- a/intentkit/core/engine.py
+++ b/intentkit/core/engine.py
@@ -118,13 +118,13 @@ async def build_agent(agent: Agent, agent_data: AgentData) -> CompiledStateGraph
                 if hasattr(skill_module, "get_skills"):
                     # all
                     skill_tools = await skill_module.get_skills(
-                        v, False, agent_store, agent_id=agent.id
+                        v, False, agent_store, agent_id=agent.id, agent=agent
                     )
                     if skill_tools and len(skill_tools) > 0:
                         tools.extend(skill_tools)
                     # private
                     skill_private_tools = await skill_module.get_skills(
-                        v, True, agent_store, agent_id=agent.id
+                        v, True, agent_store, agent_id=agent.id, agent=agent
                     )
                     if skill_private_tools and len(skill_private_tools) > 0:
                         private_tools.extend(skill_private_tools)

--- a/intentkit/skills/basename/__init__.py
+++ b/intentkit/skills/basename/__init__.py
@@ -1,6 +1,6 @@
 """Basename AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import basename_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.basename.base import BasenameBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -29,6 +32,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[BasenameBaseTool]:
     """Get all Basename skills."""
@@ -40,7 +44,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [basename_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [basename_action_provider], agent=agent
+    )
     tools: list[BasenameBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/cdp/__init__.py
+++ b/intentkit/skills/cdp/__init__.py
@@ -1,6 +1,6 @@
 """CDP wallet interaction skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import (
     cdp_api_action_provider,
@@ -16,6 +16,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.cdp.base import CDPBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -40,6 +43,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[CDPBaseTool]:
     """Get all CDP skills.
@@ -71,6 +75,7 @@ async def get_skills(
             cdp_api_action_provider,
             cdp_evm_wallet_action_provider,
         ],
+        agent=agent,
     )
     tools = []
     for skill in available_skills:

--- a/intentkit/skills/enso/base.py
+++ b/intentkit/skills/enso/base.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from intentkit.abstracts.graph import AgentContext
 from intentkit.abstracts.skill import SkillStoreABC
-from intentkit.clients import CdpClient, get_cdp_client
+from intentkit.clients import get_wallet_provider as get_agent_wallet_provider
 from intentkit.skills.base import IntentKitSkill
 from intentkit.utils.chain import ChainProvider, Network, network_to_id
 
@@ -33,8 +33,7 @@ class EnsoBaseTool(IntentKitSkill):
         Returns:
             Optional[CdpEvmWalletProvider]: The wallet provider if available.
         """
-        client: CdpClient = await get_cdp_client(context.agent.id, self.skill_store)
-        return await client.get_wallet_provider()
+        return await get_agent_wallet_provider(context.agent)
 
     async def get_wallet_address(self, context: AgentContext) -> str:
         provider: CdpEvmWalletProvider = await self.get_wallet_provider(context)

--- a/intentkit/skills/erc20/__init__.py
+++ b/intentkit/skills/erc20/__init__.py
@@ -1,6 +1,6 @@
 """ERC20 AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import erc20_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.erc20.base import ERC20BaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -30,6 +33,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[ERC20BaseTool]:
     """Get all ERC20 skills."""
@@ -41,7 +45,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [erc20_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [erc20_action_provider], agent=agent
+    )
     tools: list[ERC20BaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/erc721/__init__.py
+++ b/intentkit/skills/erc721/__init__.py
@@ -1,6 +1,6 @@
 """ERC721 AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import erc721_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.erc721.base import ERC721BaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -31,6 +34,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[ERC721BaseTool]:
     """Get all ERC721 skills."""
@@ -42,7 +46,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [erc721_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [erc721_action_provider], agent=agent
+    )
     tools: list[ERC721BaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/morpho/__init__.py
+++ b/intentkit/skills/morpho/__init__.py
@@ -1,6 +1,6 @@
 """Morpho AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import morpho_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.morpho.base import MorphoBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -30,6 +33,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[MorphoBaseTool]:
     """Get all Morpho skills."""
@@ -41,7 +45,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [morpho_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [morpho_action_provider], agent=agent
+    )
     tools: list[MorphoBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/pyth/__init__.py
+++ b/intentkit/skills/pyth/__init__.py
@@ -1,6 +1,6 @@
 """Pyth AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import pyth_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.pyth.base import PythBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -30,6 +33,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[PythBaseTool]:
     """Get all Pyth skills."""
@@ -41,7 +45,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [pyth_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [pyth_action_provider], agent=agent
+    )
     tools: list[PythBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/superfluid/__init__.py
+++ b/intentkit/skills/superfluid/__init__.py
@@ -1,6 +1,6 @@
 """Superfluid AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import superfluid_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.superfluid.base import SuperfluidBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -31,6 +34,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[SuperfluidBaseTool]:
     """Get all Superfluid skills."""
@@ -42,7 +46,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [superfluid_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [superfluid_action_provider], agent=agent
+    )
     tools: list[SuperfluidBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/weth/__init__.py
+++ b/intentkit/skills/weth/__init__.py
@@ -1,6 +1,6 @@
 """WETH AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import weth_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.weth.base import WethBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -29,6 +32,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[WethBaseTool]:
     """Get all WETH skills."""
@@ -40,7 +44,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [weth_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [weth_action_provider], agent=agent
+    )
     tools: list[WethBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/wow/__init__.py
+++ b/intentkit/skills/wow/__init__.py
@@ -1,6 +1,6 @@
 """WOW AgentKit skills."""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from coinbase_agentkit import wow_action_provider
 
@@ -12,6 +12,9 @@ from intentkit.skills.base import (
     get_agentkit_actions,
 )
 from intentkit.skills.wow.base import WowBaseTool
+
+if TYPE_CHECKING:
+    from intentkit.models.agent import Agent
 
 
 class SkillStates(TypedDict):
@@ -31,6 +34,7 @@ async def get_skills(
     is_private: bool,
     store: SkillStoreABC,
     agent_id: str,
+    agent: Optional["Agent"] = None,
     **_,
 ) -> list[WowBaseTool]:
     """Get all WOW skills."""
@@ -42,7 +46,9 @@ async def get_skills(
         if state == "public" or (state == "private" and is_private):
             available_skills.append(skill_name)
 
-    actions = await get_agentkit_actions(agent_id, store, [wow_action_provider])
+    actions = await get_agentkit_actions(
+        agent_id, store, [wow_action_provider], agent=agent
+    )
     tools: list[WowBaseTool] = []
     for skill in available_skills:
         for action in actions:

--- a/intentkit/skills/xmtp/price.py
+++ b/intentkit/skills/xmtp/price.py
@@ -50,7 +50,7 @@ class XmtpGetSwapPrice(XmtpBaseTool):
 
         network_for_cdp = self.get_cdp_network(agent.network_id)
 
-        cdp_client = get_origin_cdp_client(self.skill_store)
+        cdp_client = get_origin_cdp_client()
         # Note: Don't use async with context manager as get_origin_cdp_client returns a managed global client
         price = await cdp_client.evm.get_swap_price(
             from_token=from_token,

--- a/intentkit/skills/xmtp/swap.py
+++ b/intentkit/skills/xmtp/swap.py
@@ -108,7 +108,7 @@ class XmtpSwap(XmtpBaseTool):
         network_for_cdp = self.get_cdp_network(agent.network_id)
 
         # Get CDP client from global origin helper (server-side credentials)
-        cdp_client = get_origin_cdp_client(self.skill_store)
+        cdp_client = get_origin_cdp_client()
 
         # Call CDP to create swap quote and extract call datas
         # Be permissive with response shape across SDK versions


### PR DESCRIPTION
## Summary
- replace the CdpClient wrapper with a top-level get_wallet_provider helper that reads credentials from config and caches providers per agent
- update agent wallet processing and skills to call the new helper directly and simplify CDP client accessors
- load AgentKit-based skills with the in-memory agent context instead of querying the store so they work for non-persisted agents

## Testing
- uv run ruff format
- uv run ruff check --fix

------
https://chatgpt.com/codex/tasks/task_b_68da5b335494832fb5152126e93cacae