### PR TITLE
Add scheduled refresh jobs for agent cached data

### DIFF
--- a/app/admin/scheduler.py
+++ b/app/admin/scheduler.py
@@ -7,7 +7,12 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from intentkit.config.config import config
-from intentkit.core.agent import update_agent_action_cost
+from intentkit.core.agent import (
+    update_agent_action_cost,
+    update_agents_account_snapshot,
+    update_agents_assets,
+    update_agents_statistics,
+)
 from intentkit.core.credit import refill_all_free_credits
 from intentkit.models.agent_data import AgentQuota
 from intentkit.models.redis import get_redis, send_heartbeat
@@ -84,12 +89,39 @@ def create_scheduler():
         replace_existing=True,
     )
 
+    # Update agent account snapshots hourly
+    scheduler.add_job(
+        update_agents_account_snapshot,
+        trigger=CronTrigger(minute=0, timezone="UTC"),
+        id="update_agent_account_snapshot",
+        name="Update agent account snapshots",
+        replace_existing=True,
+    )
+
+    # Update agent assets daily at UTC midnight
+    scheduler.add_job(
+        update_agents_assets,
+        trigger=CronTrigger(hour=0, minute=0, timezone="UTC"),
+        id="update_agent_assets",
+        name="Update agent assets",
+        replace_existing=True,
+    )
+
     # Update agent action costs hourly
     scheduler.add_job(
         update_agent_action_cost,
         trigger=CronTrigger(minute=40, timezone="UTC"),
         id="update_agent_action_cost",
         name="Update agent action costs",
+        replace_existing=True,
+    )
+
+    # Update agent statistics daily at UTC 00:01
+    scheduler.add_job(
+        update_agents_statistics,
+        trigger=CronTrigger(hour=0, minute=1, timezone="UTC"),
+        id="update_agent_statistics",
+        name="Update agent statistics",
         replace_existing=True,
     )
 

--- a/intentkit/core/statistics.py
+++ b/intentkit/core/statistics.py
@@ -1,0 +1,169 @@
+"""Agent statistics utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intentkit.models.agent_data import AgentQuota, AgentQuotaTable
+from intentkit.models.credit import CreditAccount, CreditEventTable, OwnerType
+from intentkit.models.db import get_session
+
+
+class AgentStatistics(BaseModel):
+    """Aggregated statistics for an agent credit account."""
+
+    agent_id: str = Field(description="ID of the agent")
+    account_id: str = Field(description="ID of the associated credit account")
+    balance: Decimal = Field(description="Current credit account balance")
+    total_income: Decimal = Field(description="Total income across all events")
+    net_income: Decimal = Field(description="Net income from fee allocations")
+    permanent_income: Decimal = Field(
+        description="Total permanent income across all events"
+    )
+    permanent_profit: Decimal = Field(
+        description="Permanent profit allocated to the agent"
+    )
+    last_24h_income: Decimal = Field(
+        description="Income generated during the last 24 hours"
+    )
+    last_24h_permanent_income: Decimal = Field(
+        description="Permanent income generated during the last 24 hours"
+    )
+    avg_action_cost: Decimal = Field(description="Average action cost")
+    min_action_cost: Decimal = Field(description="Minimum action cost")
+    max_action_cost: Decimal = Field(description="Maximum action cost")
+    low_action_cost: Decimal = Field(description="20th percentile action cost")
+    medium_action_cost: Decimal = Field(description="60th percentile action cost")
+    high_action_cost: Decimal = Field(description="80th percentile action cost")
+
+
+async def get_agent_statistics(
+    agent_id: str,
+    *,
+    end_time: Optional[datetime] = None,
+    session: Optional[AsyncSession] = None,
+) -> AgentStatistics:
+    """Calculate statistics for an agent credit account.
+
+    Args:
+        agent_id: ID of the agent.
+        end_time: Optional end time used as the inclusive boundary for
+            time-windowed aggregations. Defaults to the current UTC time.
+        session: Optional database session to reuse. When omitted, a
+            standalone session will be created and committed automatically.
+
+    Returns:
+        Aggregated statistics for the agent.
+    """
+
+    managed_session = session is None
+    if end_time is None:
+        end_time = datetime.now(timezone.utc)
+    elif end_time.tzinfo is None:
+        end_time = end_time.replace(tzinfo=timezone.utc)
+    else:
+        end_time = end_time.astimezone(timezone.utc)
+
+    async def _compute(session: AsyncSession) -> AgentStatistics:
+        account = await CreditAccount.get_or_create_in_session(
+            session, OwnerType.AGENT, agent_id
+        )
+        balance = account.free_credits + account.reward_credits + account.credits
+
+        totals_stmt = select(
+            func.sum(CreditEventTable.total_amount).label("total_income"),
+            func.sum(CreditEventTable.fee_agent_amount).label("net_income"),
+            func.sum(CreditEventTable.permanent_amount).label("permanent_income"),
+            func.sum(CreditEventTable.fee_agent_permanent_amount).label(
+                "permanent_profit"
+            ),
+        ).where(CreditEventTable.agent_id == agent_id)
+        totals_result = await session.execute(totals_stmt)
+        totals_row = totals_result.first()
+
+        total_income = (
+            totals_row.total_income
+            if totals_row and totals_row.total_income
+            else Decimal("0")
+        )
+        net_income = (
+            totals_row.net_income
+            if totals_row and totals_row.net_income
+            else Decimal("0")
+        )
+        permanent_income = (
+            totals_row.permanent_income
+            if totals_row and totals_row.permanent_income
+            else Decimal("0")
+        )
+        permanent_profit = (
+            totals_row.permanent_profit
+            if totals_row and totals_row.permanent_profit
+            else Decimal("0")
+        )
+
+        window_start = end_time - timedelta(hours=24)
+        window_stmt = select(
+            func.sum(CreditEventTable.total_amount).label("last_24h_income"),
+            func.sum(CreditEventTable.permanent_amount).label(
+                "last_24h_permanent_income"
+            ),
+        ).where(
+            CreditEventTable.agent_id == agent_id,
+            CreditEventTable.created_at >= window_start,
+            CreditEventTable.created_at <= end_time,
+        )
+        window_result = await session.execute(window_stmt)
+        window_row = window_result.first()
+
+        last_24h_income = (
+            window_row.last_24h_income
+            if window_row and window_row.last_24h_income
+            else Decimal("0")
+        )
+        last_24h_permanent_income = (
+            window_row.last_24h_permanent_income
+            if window_row and window_row.last_24h_permanent_income
+            else Decimal("0")
+        )
+
+        quota_row = await session.get(AgentQuotaTable, agent_id)
+        quota = (
+            AgentQuota.model_validate(quota_row)
+            if quota_row
+            else AgentQuota(id=agent_id)
+        )
+
+        return AgentStatistics(
+            agent_id=agent_id,
+            account_id=account.id,
+            balance=balance,
+            total_income=total_income,
+            net_income=net_income,
+            permanent_income=permanent_income,
+            permanent_profit=permanent_profit,
+            last_24h_income=last_24h_income,
+            last_24h_permanent_income=last_24h_permanent_income,
+            avg_action_cost=quota.avg_action_cost,
+            min_action_cost=quota.min_action_cost,
+            max_action_cost=quota.max_action_cost,
+            low_action_cost=quota.low_action_cost,
+            medium_action_cost=quota.medium_action_cost,
+            high_action_cost=quota.high_action_cost,
+        )
+
+    if managed_session:
+        async with get_session() as managed:
+            statistics = await _compute(managed)
+            await managed.commit()
+            return statistics
+    return await _compute(session)
+
+
+__all__ = ["AgentStatistics", "get_agent_statistics"]


### PR DESCRIPTION
## Summary
- add a reusable core statistics helper for computing agent metrics
- refresh the admin API statistics endpoint to use the shared helper and return the shared AgentStatistics model directly
- schedule periodic jobs to cache agent account snapshots, assets, and statistics

## Testing
- uv run ruff format app/admin/credit.py
- uv run ruff check --fix app/admin/credit.py

------
https://chatgpt.com/codex/tasks/task_b_68de9da21eec832f80ac4efb85ad73f7