### PR TITLE
Fix clear command detection in stream agent

### DIFF
--- a/intentkit/core/engine.py
+++ b/intentkit/core/engine.py
@@ -293,7 +293,11 @@ async def stream_agent_raw(
     # save input message first
     user_message = await message.save()
 
-    if re.search(r"\b(@clear|/clear)\b", user_message.message.strip(), re.IGNORECASE):
+    if re.search(
+        r"(@clear|/clear)(?!\w)",
+        user_message.message.strip(),
+        re.IGNORECASE,
+    ):
         await clear_thread_memory(user_message.agent_id, user_message.chat_id)
 
         confirmation_message = ChatMessageCreate(


### PR DESCRIPTION
## Summary
- adjust clear-command detection in `stream_agent_raw` to handle @clear and /clear case-insensitively without triggering on longer tokens

## Testing
- uv run ruff format intentkit/core/engine.py
- uv run ruff check --fix intentkit/core/engine.py

------
https://chatgpt.com/codex/tasks/task_b_68ee758b7990832fa9945795b0696bbc