### PR TITLE
fix: standardize error handling in http and portfolio skills

### DIFF
--- a/intentkit/skills/http/get.py
+++ b/intentkit/skills/http/get.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional, Type
 
 import httpx
+from langchain_core.tools import ToolException
 from pydantic import BaseModel, Field
 
 from intentkit.skills.http.base import HttpBaseTool
@@ -83,12 +84,16 @@ class HttpGet(HttpBaseTool):
                 # Return response content
                 return f"Status: {response.status_code}\nContent: {response.text}"
 
-        except httpx.TimeoutException:
-            return f"Error: Request to {url} timed out after {timeout} seconds"
-        except httpx.HTTPStatusError as e:
-            return f"Error: HTTP {e.response.status_code} - {e.response.text}"
-        except httpx.RequestError as e:
-            return f"Error: Failed to connect to {url} - {str(e)}"
-        except Exception as e:
-            logger.error(f"Unexpected error in HTTP GET request: {e}")
-            return f"Error: Unexpected error occurred - {str(e)}"
+        except httpx.TimeoutException as exc:
+            raise ToolException(
+                f"Request to {url} timed out after {timeout} seconds"
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise ToolException(
+                f"HTTP {exc.response.status_code} - {exc.response.text}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ToolException(f"Failed to connect to {url} - {str(exc)}") from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Unexpected error in HTTP GET request", exc_info=exc)
+            raise ToolException(f"Unexpected error occurred - {str(exc)}") from exc

--- a/intentkit/skills/http/post.py
+++ b/intentkit/skills/http/post.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional, Type, Union
 
 import httpx
+from langchain_core.tools import ToolException
 from pydantic import BaseModel, Field
 
 from intentkit.skills.http.base import HttpBaseTool
@@ -100,12 +101,16 @@ class HttpPost(HttpBaseTool):
                 # Return response content
                 return f"Status: {response.status_code}\nContent: {response.text}"
 
-        except httpx.TimeoutException:
-            return f"Error: Request to {url} timed out after {timeout} seconds"
-        except httpx.HTTPStatusError as e:
-            return f"Error: HTTP {e.response.status_code} - {e.response.text}"
-        except httpx.RequestError as e:
-            return f"Error: Failed to connect to {url} - {str(e)}"
-        except Exception as e:
-            logger.error(f"Unexpected error in HTTP POST request: {e}")
-            return f"Error: Unexpected error occurred - {str(e)}"
+        except httpx.TimeoutException as exc:
+            raise ToolException(
+                f"Request to {url} timed out after {timeout} seconds"
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise ToolException(
+                f"HTTP {exc.response.status_code} - {exc.response.text}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ToolException(f"Failed to connect to {url} - {str(exc)}") from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Unexpected error in HTTP POST request", exc_info=exc)
+            raise ToolException(f"Unexpected error occurred - {str(exc)}") from exc

--- a/intentkit/skills/portfolio/wallet_profitability.py
+++ b/intentkit/skills/portfolio/wallet_profitability.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Type
 
+from langchain_core.tools import ToolException
 from pydantic import BaseModel, Field
 
 from intentkit.skills.portfolio.base import PortfolioBaseTool
@@ -68,11 +69,6 @@ class WalletProfitability(PortfolioBaseTool):
             f"wallet_profitability.py: Fetching profitability breakdown with context {context}"
         )
 
-        # Get the API key from the agent's configuration
-        api_key = self.get_api_key()
-        if not api_key:
-            return {"error": "No Moralis API key provided in the configuration."}
-
         # Build query parameters
         params = {
             "chain": chain,
@@ -84,16 +80,20 @@ class WalletProfitability(PortfolioBaseTool):
             params["token_addresses"] = token_addresses
 
         # Call Moralis API
+        api_key = self.get_api_key()
+
         try:
             endpoint = f"/wallets/{address}/profitability"
             return await self._make_request(
                 method="GET", endpoint=endpoint, api_key=api_key, params=params
             )
-        except Exception as e:
+        except ToolException:
+            raise
+        except Exception as exc:  # noqa: BLE001
             logger.error(
-                f"wallet_profitability.py: Error fetching profitability breakdown: {e}",
-                exc_info=True,
+                "wallet_profitability.py: Error fetching profitability breakdown",
+                exc_info=exc,
             )
-            return {
-                "error": "An error occurred while fetching profitability breakdown. Please try again later."
-            }
+            raise ToolException(
+                "An unexpected error occurred while fetching profitability breakdown."
+            ) from exc


### PR DESCRIPTION
## Summary
- update HTTP request tools to raise `ToolException` for network, timeout, and status errors instead of returning strings
- enforce `ToolException` usage for portfolio skills by validating Moralis API keys and surfacing API failures through exceptions

## Testing
- uv run ruff format intentkit/skills/http/get.py intentkit/skills/http/post.py intentkit/skills/http/put.py intentkit/skills/portfolio/base.py intentkit/skills/portfolio/wallet_approvals.py intentkit/skills/portfolio/wallet_history.py intentkit/skills/portfolio/wallet_profitability.py
- uv run ruff check --fix intentkit/skills/http/get.py intentkit/skills/http/post.py intentkit/skills/http/put.py intentkit/skills/portfolio/base.py intentkit/skills/portfolio/wallet_approvals.py intentkit/skills/portfolio/wallet_history.py intentkit/skills/portfolio/wallet_profitability.py

------
https://chatgpt.com/codex/tasks/task_b_68f6e50a9150832f84b80b04d6062224