### PR TITLE
feat: add OpenAI GPT avatar generator skill

### DIFF
--- a/intentkit/models/skills.csv
+++ b/intentkit/models/skills.csv
@@ -99,6 +99,8 @@ moralis,fetch_wallet_portfolio,moralis_fetch_wallet_portfolio,TRUE,1,5,5,,,0xd1a
 nation,nft_check,nft_check,FALSE,1,5,5,,,0x275960ad41DbE218bBf72cDF612F88b5C6f40648
 openai,dalle_image_generation,dalle_image_generation,TRUE,4,200,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
 openai,gpt_image_generation,gpt_image_generation,TRUE,5,400,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
+openai,gpt_image_mini_generator,gpt_image_mini_generator,TRUE,5,100,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
+openai,gpt_avatar_generator,gpt_avatar_generator,TRUE,5,50,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
 openai,gpt_image_to_image,gpt_image_to_image,TRUE,5,400,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
 openai,image_to_text,image_to_text,TRUE,4,200,15,,,0x445750026A4a1906b61302442E085f9cbAfe206a
 portfolio,token_balances,portfolio_token_balances,TRUE,1,5,5,,,0x3cdd051eeC909f94965F9c1c657f5b70a172B2C0

--- a/intentkit/skills/openai/__init__.py
+++ b/intentkit/skills/openai/__init__.py
@@ -6,7 +6,9 @@ from typing import TypedDict
 from intentkit.skills.base import SkillConfig, SkillState
 from intentkit.skills.openai.base import OpenAIBaseTool
 from intentkit.skills.openai.dalle_image_generation import DALLEImageGeneration
+from intentkit.skills.openai.gpt_avatar_generator import GPTAvatarGenerator
 from intentkit.skills.openai.gpt_image_generation import GPTImageGeneration
+from intentkit.skills.openai.gpt_image_mini_generator import GPTImageMiniGenerator
 from intentkit.skills.openai.gpt_image_to_image import GPTImageToImage
 from intentkit.skills.openai.image_to_text import ImageToText
 
@@ -20,6 +22,8 @@ class SkillStates(TypedDict):
     image_to_text: SkillState
     dalle_image_generation: SkillState
     gpt_image_generation: SkillState
+    gpt_image_mini_generator: SkillState
+    gpt_avatar_generator: SkillState
     gpt_image_to_image: SkillState
 
 
@@ -84,6 +88,14 @@ def get_openai_skill(
     elif name == "gpt_image_generation":
         if name not in _cache:
             _cache[name] = GPTImageGeneration()
+        return _cache[name]
+    elif name == "gpt_image_mini_generator":
+        if name not in _cache:
+            _cache[name] = GPTImageMiniGenerator()
+        return _cache[name]
+    elif name == "gpt_avatar_generator":
+        if name not in _cache:
+            _cache[name] = GPTAvatarGenerator()
         return _cache[name]
     elif name == "gpt_image_to_image":
         if name not in _cache:

--- a/intentkit/skills/openai/gpt_avatar_generator.py
+++ b/intentkit/skills/openai/gpt_avatar_generator.py
@@ -1,0 +1,105 @@
+"""GPT avatar generator skill for OpenAI."""
+
+import base64
+import logging
+
+import openai
+from epyxid import XID
+from pydantic import BaseModel, Field
+
+from intentkit.skills.openai.base import OpenAIBaseTool
+from intentkit.utils.s3 import store_image_bytes
+
+logger = logging.getLogger(__name__)
+
+AVATAR_PROMPT_PREFIX = (
+    "Create a single, centered portrait that works perfectly as a profile avatar. "
+    "Use flattering, even lighting, a simple soft-focus background, and a composition from shoulders up. "
+    "Avoid text, logos, watermarks, and distracting elements so the result feels polished and personable."
+)
+
+
+class GPTAvatarGeneratorInput(BaseModel):
+    """Input schema for the GPT avatar generator skill."""
+
+    prompt: str = Field(
+        description="Description of the avatar or profile image to generate.",
+    )
+
+
+class GPTAvatarGenerator(OpenAIBaseTool):
+    """Tool for generating avatar-friendly images using OpenAI's GPT-Image-1-Mini model."""
+
+    name: str = "gpt_avatar_generator"
+    description: str = (
+        "Generate avatar-ready profile images using OpenAI's GPT-Image-1-Mini model.\n"
+        "Provide a description of the avatar you'd like to create and the tool optimizes the prompt "
+        "for flattering, centered profile imagery.\n"
+        "Outputs are fixed to 1024x1024 resolution with medium quality and an opaque background for immediate use.\n"
+    )
+    args_schema = GPTAvatarGeneratorInput
+
+    async def _arun(self, prompt: str, **kwargs) -> str:
+        """Generate avatar-friendly images using OpenAI's GPT-Image-1-Mini model."""
+        context = self.get_context()
+        api_key = self.get_api_key()
+        job_id = str(XID())
+
+        composed_prompt = (
+            f"{AVATAR_PROMPT_PREFIX}\n{prompt.strip()}"
+            if prompt
+            else AVATAR_PROMPT_PREFIX
+        )
+
+        try:
+            client = openai.OpenAI(api_key=api_key)
+
+            response = client.images.generate(
+                model="gpt-image-1-mini",
+                prompt=composed_prompt,
+                size="1024x1024",
+                quality="medium",
+                background="opaque",
+                moderation="low",
+                n=1,
+            )
+
+            base64_image = response.data[0].b64_json
+
+            if hasattr(response, "usage") and response.usage:
+                usage = response.usage
+                logger.info(
+                    "GPT-Image-1-Mini avatar generation usage: "
+                    f"input_tokens={usage.input_tokens}, "
+                    f"output_tokens={usage.output_tokens}, "
+                    f"total_tokens={usage.total_tokens}"
+                )
+
+                if (
+                    hasattr(usage, "input_tokens_details")
+                    and usage.input_tokens_details
+                ):
+                    details = usage.input_tokens_details
+                    logger.info(f"Input tokens details: {details}")
+
+            image_bytes = base64.b64decode(base64_image)
+
+            image_key = f"{context.agent_id}/gpt-avatar/{job_id}"
+
+            stored_url = await store_image_bytes(
+                image_bytes,
+                image_key,
+                "image/jpeg",
+            )
+
+            return stored_url
+
+        except openai.OpenAIError as e:
+            error_message = f"OpenAI API error: {str(e)}"
+            logger.error(error_message)
+            raise Exception(error_message)
+
+        except Exception as e:
+            error_message = f"Error generating avatar with GPT-Image-1-Mini: {str(e)}"
+            logger.error(error_message)
+            raise Exception(error_message)

--- a/intentkit/skills/openai/gpt_image_mini_generator.py
+++ b/intentkit/skills/openai/gpt_image_mini_generator.py
@@ -1,0 +1,91 @@
+"""GPT image mini generator skill for OpenAI."""
+
+import base64
+import logging
+from typing import Literal
+
+import openai
+from epyxid import XID
+
+from intentkit.skills.openai.base import OpenAIBaseTool
+from intentkit.skills.openai.gpt_image_generation import GPTImageGenerationInput
+from intentkit.utils.s3 import store_image_bytes
+
+logger = logging.getLogger(__name__)
+
+
+class GPTImageMiniGenerator(OpenAIBaseTool):
+    """Tool for generating images using OpenAI's GPT-Image-1-Mini model."""
+
+    name: str = "gpt_image_mini_generator"
+    description: str = (
+        "Generate images using OpenAI's GPT-Image-1-Mini model.\n"
+        "Provide a text prompt describing the image you want to generate.\n"
+        "GPT-Image-1-Mini delivers high-quality images with faster performance at a lower cost.\n"
+        "You can specify size, quality, and background parameters for more control.\n"
+    )
+    args_schema = GPTImageGenerationInput
+
+    async def _arun(
+        self,
+        prompt: str,
+        size: Literal["1024x1024", "1536x1024", "1024x1536", "auto"] = "auto",
+        quality: Literal["high", "medium", "low", "auto"] = "auto",
+        background: Literal["transparent", "opaque", "auto"] = "auto",
+        **kwargs,
+    ) -> str:
+        """Generate images using OpenAI's GPT-Image-1-Mini model."""
+        context = self.get_context()
+        api_key = self.get_api_key()
+        job_id = str(XID())
+
+        try:
+            client = openai.OpenAI(api_key=api_key)
+
+            content_type = "image/png" if background == "transparent" else "image/jpeg"
+
+            response = client.images.generate(
+                model="gpt-image-1-mini",
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                background=background,
+                moderation="low",
+                n=1,
+            )
+
+            base64_image = response.data[0].b64_json
+
+            if hasattr(response, "usage") and response.usage:
+                usage = response.usage
+                logger.info(
+                    "GPT-Image-1-Mini generation usage: "
+                    f"input_tokens={usage.input_tokens}, "
+                    f"output_tokens={usage.output_tokens}, "
+                    f"total_tokens={usage.total_tokens}"
+                )
+
+                if (
+                    hasattr(usage, "input_tokens_details")
+                    and usage.input_tokens_details
+                ):
+                    details = usage.input_tokens_details
+                    logger.info(f"Input tokens details: {details}")
+
+            image_bytes = base64.b64decode(base64_image)
+
+            image_key = f"{context.agent_id}/gpt-image-mini/{job_id}"
+
+            stored_url = await store_image_bytes(image_bytes, image_key, content_type)
+
+            return stored_url
+
+        except openai.OpenAIError as e:
+            error_message = f"OpenAI API error: {str(e)}"
+            logger.error(error_message)
+            raise Exception(error_message)
+
+        except Exception as e:
+            error_message = f"Error generating image with GPT-Image-1-Mini: {str(e)}"
+            logger.error(error_message)
+            raise Exception(error_message)

--- a/intentkit/skills/openai/schema.json
+++ b/intentkit/skills/openai/schema.json
@@ -66,6 +66,38 @@
           "description": "Generate images using OpenAI's GPT-Image-1 model based on text prompts",
           "default": "private"
         },
+        "gpt_image_mini_generator": {
+          "type": "string",
+          "title": "Image Generation by GPT Mini",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Generate images using OpenAI's GPT-Image-1-Mini model based on text prompts",
+          "default": "private"
+        },
+        "gpt_avatar_generator": {
+          "type": "string",
+          "title": "Avatar Generation by GPT Mini",
+          "enum": [
+            "disabled",
+            "public",
+            "private"
+          ],
+          "x-enum-title": [
+            "Disabled",
+            "Agent Owner + All Users",
+            "Agent Owner Only"
+          ],
+          "description": "Generate avatar-ready profile images using OpenAI's GPT-Image-1-Mini model",
+          "default": "private"
+        },
         "gpt_image_to_image": {
           "type": "string",
           "title": "Image Editing by GPT",


### PR DESCRIPTION
## Summary
- add a gpt_avatar_generator skill that wraps the GPT-Image-1-Mini model with avatar-focused prompting and fixed output settings
- expose the avatar generator through the OpenAI skill registry and configuration schema
- list the new skill in the catalog with pricing set to half of the mini image generator

## Testing
- ruff format
- ruff check --fix

------
https://chatgpt.com/codex/tasks/task_b_690819ca9d70832f8fb7fee984171919