### PR TITLE
fix: use EVM account for LiFi execution

### DIFF
--- a/intentkit/skills/lifi/base.py
+++ b/intentkit/skills/lifi/base.py
@@ -1,9 +1,9 @@
 from pydantic import BaseModel, Field
 
-from intentkit.skills.base import IntentKitSkill
+from intentkit.skills.onchain import IntentKitOnChainSkill
 
 
-class LiFiBaseTool(IntentKitSkill):
+class LiFiBaseTool(IntentKitOnChainSkill):
     """Base class for LiFi tools."""
 
     name: str = Field(description="The name of the tool")


### PR DESCRIPTION
## Summary
- extend the LiFi base tool from the shared on-chain helper to expose the CDP EVM account utilities
- refactor `token_execute` to fetch the EVM account via the skill, send transactions asynchronously, and manage approvals/receipts with Web3
- add helpers for building EIP-1559 requests and waiting for receipts while removing the wallet provider dependency

## Testing
- ruff format intentkit/skills/lifi/base.py intentkit/skills/lifi/token_execute.py
- ruff check --fix intentkit/skills/lifi/base.py intentkit/skills/lifi/token_execute.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916f7e9dd24832f8c4f067485d8fadb)