### PR TITLE
Refactor agent middleware for LangChain v1 migration

### DIFF
--- a/intentkit/core/node.py
+++ b/intentkit/core/node.py
@@ -1,40 +1,36 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Sequence
 from typing import Any
 
-from langchain_core.language_models import LanguageModelLike
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain_core.messages import (
     AIMessage,
-    AnyMessage,
     BaseMessage,
-    HumanMessage,
     RemoveMessage,
     ToolMessage,
 )
 from langchain_core.messages.utils import count_tokens_approximately, trim_messages
+from langchain_core.tools import BaseTool
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
-from langgraph.runtime import get_runtime
-from langgraph.utils.runnable import RunnableCallable
-from langmem.short_term.summarization import (
-    DEFAULT_EXISTING_SUMMARY_PROMPT,
-    DEFAULT_FINAL_SUMMARY_PROMPT,
-    DEFAULT_INITIAL_SUMMARY_PROMPT,
-    SummarizationResult,
-    asummarize_messages,
-)
+from langgraph.runtime import Runtime
+from langgraph.types import StreamWriter
 
 from intentkit.abstracts.graph import AgentContext, AgentError, AgentState
 from intentkit.core.credit import skill_cost
+from intentkit.core.prompt import build_system_prompt
 from intentkit.models.credit import CreditAccount, OwnerType
+from intentkit.models.llm import LLMModelInfo, LLMProvider
 from intentkit.models.skill import Skill
 
 logger = logging.getLogger(__name__)
 
 
-def _validate_chat_history(
-    messages: Sequence[BaseMessage],
-) -> None:
+def _validate_chat_history(messages: Sequence[BaseMessage]) -> None:
     """Validate that all tool calls in AIMessages have a corresponding ToolMessage."""
+
     all_tool_calls = [
         tool_call
         for message in messages
@@ -57,158 +53,177 @@ def _validate_chat_history(
     raise ValueError(message)
 
 
-class PreModelNode(RunnableCallable):
-    """LangGraph node that run before the LLM is called."""
+class TrimMessagesMiddleware(AgentMiddleware[AgentState, AgentContext]):
+    """Middleware that trims conversation history before invoking the model."""
 
-    def __init__(
-        self,
-        *,
-        model: LanguageModelLike,
-        short_term_memory_strategy: str,
-        max_tokens: int,
-        max_summary_tokens: int = 2048,
-    ) -> None:
-        super().__init__(self._func, self._afunc, name="pre_model_node", trace=False)
-        self.model = model
-        self.short_term_memory_strategy = short_term_memory_strategy
-        self.max_tokens = max_tokens
-        self.max_tokens_before_summary = max_tokens
+    def __init__(self, *, max_summary_tokens: int) -> None:
+        super().__init__()
         self.max_summary_tokens = max_summary_tokens
-        self.token_counter = count_tokens_approximately
-        self.initial_summary_prompt = DEFAULT_INITIAL_SUMMARY_PROMPT
-        self.existing_summary_prompt = DEFAULT_EXISTING_SUMMARY_PROMPT
-        self.final_prompt = DEFAULT_FINAL_SUMMARY_PROMPT
-        self.func_accepts_config = True
 
-    def _parse_input(
-        self, state: AgentState
-    ) -> tuple[list[AnyMessage], dict[str, Any]]:
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime[AgentContext]
+    ) -> dict[str, Any]:
+        del runtime
         messages = state.get("messages")
         context = state.get("context", {})
         if messages is None or not isinstance(messages, list) or len(messages) == 0:
             raise ValueError("Missing required field `messages` in the input.")
-        return messages, context
-
-    # overwrite old messages if summarization is used
-    def _prepare_state_update(
-        self, context: dict[str, Any], summarization_result: SummarizationResult
-    ) -> dict[str, Any]:
-        state_update = {
-            "messages": [RemoveMessage(REMOVE_ALL_MESSAGES)]
-            + summarization_result.messages
-        }
-        if summarization_result.running_summary:
-            state_update["context"] = {
-                **context,
-                "running_summary": summarization_result.running_summary,
-            }
-        return state_update
-
-    def _func(self, AgentState) -> dict[str, Any]:
-        raise NotImplementedError("Not implemented yet")
-
-    async def _afunc(self, state: AgentState) -> dict[str, Any]:
-        messages, context = self._parse_input(state)
         try:
             _validate_chat_history(messages)
         except ValueError as e:
             logger.error(f"Invalid chat history: {e}")
             logger.info(state)
-            # delete all messages
             return {"messages": [RemoveMessage(REMOVE_ALL_MESSAGES)]}
-        if self.short_term_memory_strategy == "trim":
-            trimmed_messages = trim_messages(
-                messages,
-                strategy="last",
-                token_counter=self.token_counter,
-                max_tokens=self.max_summary_tokens,
-                start_on="human",
-                end_on=("human", "tool"),
-            )
-            if len(trimmed_messages) < len(messages):
-                logger.info(
-                    f"Trimmed messages: {len(messages)} -> {len(trimmed_messages)}"
-                )
-                if len(trimmed_messages) <= 3:
-                    logger.info(f"Too few messages after trim: {len(trimmed_messages)}")
-                    return {}
-                return {
-                    "messages": [RemoveMessage(REMOVE_ALL_MESSAGES)] + trimmed_messages,
-                }
-            else:
+
+        trimmed_messages = trim_messages(
+            messages,
+            strategy="last",
+            token_counter=count_tokens_approximately,
+            max_tokens=self.max_summary_tokens,
+            start_on="human",
+            end_on=("human", "tool"),
+        )
+        if len(trimmed_messages) < len(messages):
+            logger.info(f"Trimmed messages: {len(messages)} -> {len(trimmed_messages)}")
+            if len(trimmed_messages) <= 3:
+                logger.info(f"Too few messages after trim: {len(trimmed_messages)}")
                 return {}
-        if self.short_term_memory_strategy == "summarize":
-            # if last message is not human message, skip summarize
-            if not isinstance(messages[-1], HumanMessage):
-                return {}
-            # summarization is from outside, sometimes it is not stable, so we need to try-catch it
-            try:
-                summarization_result = await asummarize_messages(
-                    messages,
-                    running_summary=context.get("running_summary"),
-                    model=self.model,
-                    max_tokens=self.max_tokens,
-                    max_tokens_before_summary=self.max_tokens_before_summary,
-                    max_summary_tokens=self.max_summary_tokens,
-                    token_counter=self.token_counter,
-                    initial_summary_prompt=self.initial_summary_prompt,
-                    existing_summary_prompt=self.existing_summary_prompt,
-                    final_prompt=self.final_prompt,
-                )
-                if summarization_result.running_summary:
-                    logger.debug(f"Summarization result: {summarization_result}")
-                else:
-                    logger.debug("Summarization not run")
-                return self._prepare_state_update(context, summarization_result)
-            except ValueError as e:
-                logger.error(f"Invalid chat history: {e}")
-                logger.info(state)
-                # delete all messages
-                return {"messages": [RemoveMessage(REMOVE_ALL_MESSAGES)]}
-        raise ValueError(
-            f"Invalid short_term_memory_strategy: {self.short_term_memory_strategy}"
+            return {
+                "messages": [RemoveMessage(REMOVE_ALL_MESSAGES)] + trimmed_messages,
+                "context": context,
+            }
+        return {}
+
+
+class DynamicPromptMiddleware(AgentMiddleware[AgentState, AgentContext]):
+    """Middleware that builds the system prompt dynamically per request."""
+
+    def __init__(self, agent, agent_data) -> None:
+        super().__init__()
+        self.agent = agent
+        self.agent_data = agent_data
+
+    async def awrap_model_call(self, request, handler):  # type: ignore[override]
+        context = request.runtime.context
+        system_prompt = await build_system_prompt(self.agent, self.agent_data, context)
+        updated_request = request.override(system_prompt=system_prompt)
+        return await handler(updated_request)
+
+
+class ToolBindingMiddleware(AgentMiddleware[AgentState, AgentContext]):
+    """Middleware that selects tools and model parameters based on context."""
+
+    def __init__(
+        self,
+        llm_model: LLMModelInfo,
+        public_tools: list[BaseTool | dict],
+        private_tools: list[BaseTool | dict],
+    ) -> None:
+        super().__init__()
+        self.llm_model = llm_model
+        self.public_tools = public_tools
+        self.private_tools = private_tools
+
+    async def awrap_model_call(self, request, handler):  # type: ignore[override]
+        context = request.runtime.context
+
+        llm_params: dict[str, Any] = {}
+        tools: list[BaseTool | dict] = (
+            self.private_tools if context.is_private else self.public_tools
+        )
+        tools = list(
+            {
+                tool.name if isinstance(tool, BaseTool) else str(tool): tool
+                for tool in tools
+            }.values()
         )
 
+        if context.search or context.agent.has_search():
+            if self.llm_model.info.supports_search:
+                tools.append({"type": "web_search"})
+                if (
+                    self.llm_model.info.provider == LLMProvider.OPENAI
+                    and self.llm_model.model_name == "gpt-5-mini"
+                ):
+                    llm_params["reasoning_effort"] = "medium"
+                if self.llm_model.info.provider == LLMProvider.XAI:
+                    llm_params["search_parameters"] = {"mode": "auto"}
+            else:
+                logger.debug(
+                    "Search requested but model does not support native search"
+                )
 
-class PostModelNode(RunnableCallable):
+        model = await self.llm_model.create_instance(llm_params)
+        updated_request = request.override(
+            model=model,
+            tools=tools,
+            model_settings=llm_params,
+        )
+        return await handler(updated_request)
+
+
+class CreditCheckMiddleware(AgentMiddleware[AgentState, AgentContext]):
+    """Middleware that validates tool affordability before execution."""
+
     def __init__(self) -> None:
-        super().__init__(self._func, self._afunc, name="post_model_node", trace=False)
+        super().__init__()
         self.func_accepts_config = True
 
-    def _func(self, state: AgentState) -> dict[str, Any]:
-        raise NotImplementedError("Not implemented yet")
-
-    async def _afunc(self, state: AgentState) -> dict[str, Any]:
-        runtime = get_runtime(AgentContext)
+    async def aafter_model(
+        self,
+        state: AgentState,
+        runtime: Runtime[AgentContext],
+        *,
+        writer: StreamWriter | None = None,
+    ) -> dict[str, Any]:
         context = runtime.context
-        logger.debug(f"Running PostModelNode, input: {state}, context: {context}")
-        state_update = {}
         messages = state.get("messages")
         if messages is None or not isinstance(messages, list) or len(messages) == 0:
             raise ValueError("Missing required field `messages` in the input.")
+
         payer = context.payer
         if not payer:
-            return state_update
-        logger.debug(f"last: {messages[-1]}")
+            return {}
+
         msg = messages[-1]
         agent = context.agent
         account = await CreditAccount.get_or_create(OwnerType.USER, payer)
         if hasattr(msg, "tool_calls") and msg.tool_calls:
             for tool_call in msg.tool_calls:
                 skill_meta = await Skill.get(tool_call.get("name"))
-                if skill_meta:
-                    skill_cost_info = await skill_cost(skill_meta.name, payer, agent)
-                    total_paid = skill_cost_info.total_amount
-                    if not account.has_sufficient_credits(total_paid):
-                        state_update["error"] = AgentError.INSUFFICIENT_CREDITS
-                        state_update["messages"] = [RemoveMessage(id=msg.id)]
-                        state_update["messages"].append(
-                            AIMessage(
-                                content=f"Insufficient credits. Please top up your account. You need {total_paid} credits, but you only have {account.balance} credits.",
-                            )
+                if not skill_meta:
+                    continue
+                skill_cost_info = await skill_cost(skill_meta.name, payer, agent)
+                total_paid = skill_cost_info.total_amount
+                if not account.has_sufficient_credits(total_paid):
+                    error_message = (
+                        "Insufficient credits. Please top up your account. "
+                        f"You need {total_paid} credits, but you only have {account.balance} credits."
+                    )
+                    state_update: dict[str, Any] = {
+                        "error": AgentError.INSUFFICIENT_CREDITS,
+                        "messages": [
+                            RemoveMessage(id=msg.id),
+                            AIMessage(content=error_message),
+                        ],
+                    }
+                    if writer:
+                        writer(
+                            {
+                                "credit_check": {
+                                    "error": AgentError.INSUFFICIENT_CREDITS,
+                                    "message": error_message,
+                                }
+                            }
                         )
-                        return state_update
-        return state_update
+                    return state_update
+        return {}
 
 
-post_model_node = PostModelNode()
+__all__ = [
+    "CreditCheckMiddleware",
+    "DynamicPromptMiddleware",
+    "SummarizationMiddleware",
+    "ToolBindingMiddleware",
+    "TrimMessagesMiddleware",
+]


### PR DESCRIPTION
## Summary
- switch agent construction to `langchain.agents.create_agent` with middleware-driven prompt, tool, and credit handling
- replace legacy pre/post model nodes with dynamic prompt, tool binding, trimming/summarization, and credit check middlewares
- adapt prompt building and streaming flow to align with LangChain v1 static prompts and custom credit check updates

## Testing
- ruff format
- ruff check --fix
- basedpyright *(not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b005b5a58832fad6e7a6dde558874)