### PR TITLE
feat: add dev and prod docker image tags for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable=${{ github.event_name == 'release' && github.event.action == 'prereleased' }}
+            type=raw,value=prod,enable=${{ github.event_name == 'release' && github.event.action == 'released' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5


### PR DESCRIPTION
This PR adds automatic Docker image tagging for releases:
- Adds 'dev' tag for pre-release builds
- Adds 'prod' tag for production releases

This enables easier identification and deployment of different release types.