### PR TITLE
ci(frontend): add workflow for lint and build

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,36 @@
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: cd frontend && pnpm install
+
+      - name: Run lint
+        run: cd frontend && pnpm lint
+
+      - name: Run build
+        run: cd frontend && pnpm build


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run lint and build for the frontend project on every push/pull_request. It uses pnpm for dependency management.