### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/intentkit/models/llm.csv
+++ b/intentkit/models/llm.csv
@@ -2,6 +2,7 @@ id,name,provider,enabled,input_price,cached_input_price,output_price,price_level
 google/gemma-4-31b-it:free,Gemma 4 31B (Free),openrouter,TRUE,0,,0,1,262144,32768,3,4,TRUE,FALSE,TRUE,FALSE,high,TRUE,TRUE,TRUE,300
 openrouter/free,OpenRouter Free,openrouter,TRUE,0,,0,1,200000,20000,2,2,FALSE,FALSE,FALSE,FALSE,high,TRUE,TRUE,TRUE,300
 qwen/qwen3.6-plus,Qwen3.6 Plus,openrouter,TRUE,0.325,,1.95,2,1000000,65536,4,4,TRUE,FALSE,TRUE,FALSE,high,TRUE,TRUE,TRUE,300
+minimax/minimax-m3,MiniMax M3,openrouter,TRUE,0.3,0.03,1.2,2,1048576,131072,5,3,TRUE,FALSE,TRUE,FALSE,high,TRUE,TRUE,TRUE,300
 minimax/minimax-m2.7,MiniMax M2.7,openrouter,TRUE,0.3,0.03,1.2,2,204800,131072,5,3,FALSE,FALSE,FALSE,FALSE,high,TRUE,TRUE,TRUE,300
 minimax/minimax-m2-her,Minimax M2 Her,openrouter,TRUE,0.3,0.03,1.2,2,65536,2048,3,3,FALSE,FALSE,FALSE,FALSE,none,TRUE,TRUE,TRUE,300
 xiaomi/mimo-v2-pro,MiMo V2 Pro,openrouter,TRUE,1,,3,3,1048576,131072,5,2,FALSE,FALSE,FALSE,FALSE,high,TRUE,TRUE,TRUE,300
@@ -36,4 +37,5 @@ grok-4-1-fast-non-reasoning,Grok 4.1 Fast,xai,TRUE,0.2,0.05,0.5,2,2000000,4096,3
 x-ai/grok-4.1-fast,Grok 4.1 Fast,openrouter,TRUE,0.2,0.05,0.5,2,2000000,4096,3,4,TRUE,FALSE,FALSE,TRUE,none,TRUE,TRUE,TRUE,180
 grok-4-1-fast-reasoning,Grok 4.1 Fast Reasoning,xai,TRUE,0.2,0.05,0.5,2,2000000,4096,3,4,TRUE,FALSE,FALSE,TRUE,high,TRUE,FALSE,FALSE,180
 x-ai/grok-4.1-fast-reasoning,Grok 4.1 Fast Reasoning,openrouter,TRUE,0.2,0.05,0.5,2,2000000,4096,3,4,TRUE,FALSE,FALSE,TRUE,high,TRUE,TRUE,TRUE,180
+MiniMax-M3,MiniMax M3,minimax,TRUE,0.6,0.12,2.4,2,1048576,131072,5,3,TRUE,FALSE,FALSE,FALSE,high,TRUE,TRUE,TRUE,300
 MiniMax-M2.7,MiniMax M2.7,minimax,TRUE,0.1,0.01,0.4,1,204800,131072,5,3,FALSE,FALSE,FALSE,FALSE,high,TRUE,TRUE,TRUE,300

--- a/intentkit/models/llm_picker.py
+++ b/intentkit/models/llm_picker.py
@@ -16,7 +16,7 @@ def pick_summarize_model() -> str:
         ("gpt-5.4-mini", LLMProvider.OPENAI),
         ("grok-4-1-fast-non-reasoning", LLMProvider.XAI),
         ("deepseek-chat", LLMProvider.DEEPSEEK),
-        ("MiniMax-M2.7", LLMProvider.MINIMAX),
+        ("MiniMax-M3", LLMProvider.MINIMAX),
     ]
     if (
         LLMProvider.OPENAI_COMPATIBLE.is_configured
@@ -48,8 +48,8 @@ def pick_default_model() -> str:
     """
     order: list[tuple[str, LLMProvider]] = [
         ("gemini-3-flash-preview", LLMProvider.GOOGLE),
-        ("MiniMax-M2.7", LLMProvider.MINIMAX),
-        ("minimax/minimax-m2.7", LLMProvider.OPENROUTER),
+        ("MiniMax-M3", LLMProvider.MINIMAX),
+        ("minimax/minimax-m3", LLMProvider.OPENROUTER),
         ("gpt-5.4-mini", LLMProvider.OPENAI),
         ("grok-4-1-fast-non-reasoning", LLMProvider.XAI),
         ("deepseek-chat", LLMProvider.DEEPSEEK),
@@ -109,7 +109,7 @@ def pick_long_context_model() -> str:
         ("qwen/qwen3.5-flash-02-23", LLMProvider.OPENROUTER),
         ("gpt-5.4-nano", LLMProvider.OPENAI),
         ("deepseek-chat", LLMProvider.DEEPSEEK),
-        ("MiniMax-M2.7", LLMProvider.MINIMAX),
+        ("MiniMax-M3", LLMProvider.MINIMAX),
     ]
     if LLMProvider.OPENAI_COMPATIBLE.is_configured and config.openai_compatible_model:
         order.append((config.openai_compatible_model, LLMProvider.OPENAI_COMPATIBLE))


### PR DESCRIPTION
## Summary

Upgrade the default MiniMax model from M2.7 to M3 across the LLM picker logic, and add the M3 model entries to `intentkit/models/llm.csv`.

## Changes

- Add `MiniMax-M3` row to `intentkit/models/llm.csv` for the direct `minimax` provider (1M context, $0.6/$2.4 per M tokens, $0.12 cache read, image input).
- Add `minimax/minimax-m3` row for the OpenRouter provider (1M context, $0.3/$1.2 per M tokens, image + video input).
- Update `pick_summarize_model`, `pick_default_model`, and `pick_long_context_model` in `intentkit/models/llm_picker.py` to use `MiniMax-M3` instead of `MiniMax-M2.7`.
- `pick_default_model` also references `minimax/minimax-m3` (was `minimax/minimax-m2.7`) for the OpenRouter fallback.
- Retain `MiniMax-M2.7` and `minimax/minimax-m2.7` entries in `llm.csv` so existing agents pinned to M2.7 keep working.

## Why

[MiniMax-M3](https://platform.minimax.io/docs/guides/text-generation) is the latest MiniMax flagship: a multimodal foundation model with a 1M-token context window built on MiniMax Sparse Attention (MSA) for substantially faster prefill / decode at long context. It also gains native image input support, which the existing Anthropic-compatible integration in `MiniMaxLLM` can pass through.

## Testing

- `ruff format` / `ruff check` clean on the changed files.
- `python -m py_compile` of the changed Python files succeeds.
- CSV schema validated: M3 rows parse correctly, M2.7 rows preserved for backward compatibility, no older M2.5/M2.1/M2/M1 rows present.
- Picker model lookup verified by static parse: `MiniMax-M3` is referenced in all three picker functions where M2.7 was previously used; no stale `MiniMax-M2.7` references remain in the picker.