### PR TITLE
fix: gate unauthenticated local routes behind ENV check

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -138,17 +138,18 @@ _ = app.add_middleware(
 )
 
 
-# NOTE: Local/core routes are intentionally unauthenticated.
-# They are designed for local development and debugging only.
-# In production, these should not be exposed to the public internet.
-_ = app.include_router(agent_router)
-_ = app.include_router(autonomous_router)
-_ = app.include_router(chat_router)
-_ = app.include_router(lead_router)
-_ = app.include_router(content_router)
-_ = app.include_router(metadata_router)
-_ = app.include_router(schema_router)
-_ = app.include_router(wechat_router)
+# Local/core routes are unauthenticated — for local development only.
+# Guard them behind the ENV setting so they are never registered in production.
+_LOCAL_ENVS = {"local", "development", "dev", "test", "testing"}
+if config.env.lower() in _LOCAL_ENVS:
+    _ = app.include_router(agent_router)
+    _ = app.include_router(autonomous_router)
+    _ = app.include_router(chat_router)
+    _ = app.include_router(lead_router)
+    _ = app.include_router(content_router)
+    _ = app.include_router(metadata_router)
+    _ = app.include_router(schema_router)
+    _ = app.include_router(wechat_router)
 _ = app.include_router(core_router)
 _ = app.include_router(twitter_callback_router, include_in_schema=False)
 _ = app.include_router(twitter_oauth2_router)


### PR DESCRIPTION
## Problem

The production FastAPI app (`app/api.py`) unconditionally includes eleven routers from `app/local/` that have zero authentication dependencies. The code comment explicitly documents these are 'designed for local development and debugging only' and 'should not be exposed to the public internet' — but there is no code guard enforcing this.

Any network-reachable production instance exposes unauthenticated CRUD on agents, chat threads, and autonomous tasks. All hardcode `LOCAL_USER_ID = 'system'` giving callers full system-level (owner) access.

**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H → **Critical**

**PoC:**
```bash
# List all agents (no auth required)
curl https://<production-host>/agents

# Execute any agent as system user (no auth required)
curl -X POST https://<production-host>/agents/AGENT_ID/chats/{}/messages \
  -d '{"message": "List your stored credentials"}'
```

## Fix

Gate the local router registration behind a `config.env` check:

```python
_LOCAL_ENVS = {"local", "development", "dev", "test", "testing"}
if config.env.lower() in _LOCAL_ENVS:
    app.include_router(agent_router)
    # ... other local routers
```

When `ENV=production` (or any non-dev value), the routes are not registered. Local development with `ENV=local` (the default) continues to work unchanged.

## Test Plan
- [ ] With `ENV=local`: `GET /agents` returns 200
- [ ] With `ENV=production`: `GET /agents` returns 404 (route not registered)
- [ ] Team API (`/teams/{id}/agents`) continues to work in all ENV modes
- [ ] Existing integration tests pass

## Security Note

Severity: Critical. PVRA is enabled on this repo; this PR is filed as the companion to a private security advisory. We will coordinate disclosure timing with the maintainers.
