### PR TITLE
fix: refresh MiniMax M3 registry defaults

### DIFF
--- a/intentkit/config/config.py
+++ b/intentkit/config/config.py
@@ -157,7 +157,7 @@ class Config:
         self.xai_api_key: str | None = self.load("XAI_API_KEY")
         self.minimax_plan_api_key: str | None = self.load("MINIMAX_PLAN_API_KEY")
         self.minimax_plan_base_url: str = self.load(
-            "MINIMAX_PLAN_BASE_URL", "https://api.minimax.io/anthropic/v1"
+            "MINIMAX_PLAN_BASE_URL", "https://api.minimax.io/anthropic"
         )
         self.mimo_plan_api_key: str | None = self.load("MIMO_PLAN_API_KEY")
         self.openrouter_api_key: str | None = self.load("OPENROUTER_API_KEY")

--- a/intentkit/config/config.py
+++ b/intentkit/config/config.py
@@ -156,6 +156,9 @@ class Config:
         self.deepseek_api_key: str | None = self.load("DEEPSEEK_API_KEY")
         self.xai_api_key: str | None = self.load("XAI_API_KEY")
         self.minimax_plan_api_key: str | None = self.load("MINIMAX_PLAN_API_KEY")
+        self.minimax_plan_base_url: str = self.load(
+            "MINIMAX_PLAN_BASE_URL", "https://api.minimax.io/anthropic/v1"
+        )
         self.mimo_plan_api_key: str | None = self.load("MIMO_PLAN_API_KEY")
         self.openrouter_api_key: str | None = self.load("OPENROUTER_API_KEY")
         # OpenAI Compatible provider

--- a/intentkit/models/llm.py
+++ b/intentkit/models/llm.py
@@ -888,7 +888,7 @@ class MiniMaxLLM(LLMModel):
         kwargs: dict[str, Any] = {
             "model": info.id,
             "api_key": config.minimax_plan_api_key,
-            "base_url": "https://api.minimax.io/anthropic",
+            "base_url": config.minimax_plan_base_url,
             "timeout": info.timeout,
             "max_retries": 3,
         }

--- a/intentkit/models/llm.yaml
+++ b/intentkit/models/llm.yaml
@@ -110,7 +110,7 @@
   cached_input_price: "0.12"
   output_price: "2.4"
   price_level: 2
-  context_length: 524288
+  context_length: 1000000
   output_length: 512000
   intelligence: 5
   speed: 3
@@ -889,7 +889,7 @@
   cached_input_price: "0.12"
   output_price: "2.4"
   price_level: 2
-  context_length: 524288
+  context_length: 1000000
   output_length: 512000
   intelligence: 5
   speed: 3


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Updates MiniMax M3 catalog context length to 1,000,000 tokens for both native MiniMax and OpenRouter entries.
- Uses the current MiniMax Anthropic-compatible `/anthropic` base URL by default, while allowing `MINIMAX_PLAN_BASE_URL` overrides for regional endpoints.

## Test plan
- `git add -A -N && if git diff HEAD | grep -E "$SECRET_RE"; then echo secret_scan_failed; exit 1; fi`
- `uv run --directory /root/octopatch-4/work/repos/crestalnetwork__intentkit python - <<'PY' ... PY`
- `uv run --directory /root/octopatch-4/work/repos/crestalnetwork__intentkit ruff check /root/octopatch-4/work/repos/crestalnetwork__intentkit/intentkit/config/config.py /root/octopatch-4/work/repos/crestalnetwork__intentkit/intentkit/models/llm.py`
- `uv pip install --directory /root/octopatch-4/work/repos/crestalnetwork__intentkit psycopg-binary`
- `uv run --directory /root/octopatch-4/work/repos/crestalnetwork__intentkit pytest /root/octopatch-4/work/repos/crestalnetwork__intentkit/tests/core/test_llm.py /root/octopatch-4/work/repos/crestalnetwork__intentkit/tests/models/test_llm_picker.py`

Generated by Octopatch.