### PR TITLE
Refresh MiniMax model parameters and endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ GOOGLE_API_KEY=
 GOOGLE_GENAI_USE_VERTEXAI=false
 #GOOGLE_CLOUD_PROJECT=
 MINIMAX_PLAN_API_KEY=
+# Global: https://api.minimax.io/anthropic
+# China: https://api.minimaxi.com/anthropic
+MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
 MIMO_PLAN_API_KEY=
 
 # OpenAI Compatible Provider

--- a/intentkit/config/config.py
+++ b/intentkit/config/config.py
@@ -156,6 +156,9 @@ class Config:
         self.deepseek_api_key: str | None = self.load("DEEPSEEK_API_KEY")
         self.xai_api_key: str | None = self.load("XAI_API_KEY")
         self.minimax_plan_api_key: str | None = self.load("MINIMAX_PLAN_API_KEY")
+        self.minimax_anthropic_base_url: str = self.load(
+            "MINIMAX_ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic"
+        )
         self.mimo_plan_api_key: str | None = self.load("MIMO_PLAN_API_KEY")
         self.openrouter_api_key: str | None = self.load("OPENROUTER_API_KEY")
         # OpenAI Compatible provider

--- a/intentkit/models/llm.py
+++ b/intentkit/models/llm.py
@@ -888,7 +888,7 @@ class MiniMaxLLM(LLMModel):
         kwargs: dict[str, Any] = {
             "model": info.id,
             "api_key": config.minimax_plan_api_key,
-            "base_url": "https://api.minimax.io/anthropic",
+            "base_url": config.minimax_anthropic_base_url,
             "timeout": info.timeout,
             "max_retries": 3,
         }

--- a/intentkit/models/llm.yaml
+++ b/intentkit/models/llm.yaml
@@ -889,7 +889,7 @@
   cached_input_price: "0.12"
   output_price: "2.4"
   price_level: 2
-  context_length: 524288
+  context_length: 1000000
   output_length: 512000
   intelligence: 5
   speed: 3
@@ -901,4 +901,24 @@
   supports_temperature: true
   supports_frequency_penalty: true
   supports_presence_penalty: true
+  timeout: 300
+
+- id: "MiniMax-M2.7"
+  name: "MiniMax M2.7"
+  provider: minimax
+  enabled: true
+  input_price: "0.3"
+  cached_input_price: "0.06"
+  output_price: "1.2"
+  price_level: 2
+  context_length: 204800
+  output_length: 131072
+  intelligence: 4
+  speed: 4
+  supports_image_input: false
+  supports_audio_input: false
+  supports_video_input: false
+  supports_file_input: false
+  reasoning_effort: "high"
+  supports_temperature: false
   timeout: 300

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -3,6 +3,16 @@ from unittest.mock import patch
 from intentkit.models.llm import LLMProvider, load_default_llm_models
 
 
+def test_minimax_catalog_contains_current_models():
+    """The native MiniMax catalog mirrors the current subscription API lineup."""
+    with patch("intentkit.models.llm.config") as mock_config:
+        mock_config.minimax_plan_api_key = "test-key"
+        models = load_default_llm_models()
+
+    assert models["minimax:MiniMax-M3"].context_length == 1_000_000
+    assert models["minimax:MiniMax-M2.7"].context_length == 204_800
+
+
 def test_llm_model_filtering():
     """Test that models are filtered based on available API keys in config."""
 

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -7,6 +7,12 @@ def test_minimax_catalog_contains_current_models():
     """The native MiniMax catalog mirrors the current subscription API lineup."""
     with patch("intentkit.models.llm.config") as mock_config:
         mock_config.minimax_plan_api_key = "test-key"
+        mock_config.openai_compatible_api_key = None
+        mock_config.openai_compatible_base_url = None
+        mock_config.openai_compatible_model = None
+        mock_config.anthropic_compatible_api_key = None
+        mock_config.anthropic_compatible_base_url = None
+        mock_config.anthropic_compatible_model = None
         models = load_default_llm_models()
 
     assert models["minimax:MiniMax-M3"].context_length == 1_000_000


### PR DESCRIPTION
## Summary

- add the native MiniMax M2.7 model with its current context window and pricing
- update MiniMax M3 to its 1,000,000-token context window
- make the Anthropic-compatible MiniMax endpoint configurable and document both global and China endpoints
- add a catalog regression test for the current native MiniMax lineup

## Validation

- `python3` YAML catalog assertions
- `python3 -m compileall -q intentkit/config/config.py intentkit/models/llm.py tests/core/test_llm.py`
- `git diff --check`

The targeted pytest run could not start because the environment dependency download stalled; no test failures were observed.